### PR TITLE
Add color picker input field support

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -241,8 +241,7 @@ System.config({
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "ieee754": "npm:ieee754@1.1.8",
       "isarray": "npm:isarray@1.0.0",
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@1.2.7": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",

--- a/client/src/elements/schema-editor/schema-editor-color.css
+++ b/client/src/elements/schema-editor/schema-editor-color.css
@@ -1,0 +1,4 @@
+schema-editor-color input[type='color'] {
+  width: 100px;
+  height: 40px;
+}

--- a/client/src/elements/schema-editor/schema-editor-color.html
+++ b/client/src/elements/schema-editor/schema-editor-color.html
@@ -1,0 +1,7 @@
+<template class="schema-editor-input" bindable="schema, data, change, required">
+  <require from="./schema-editor-color.css"></require>
+  <label>
+    ${schema["title"]}
+    <input type="color" value.bind="data" required.bind="required" keyup.delegate="change() & debounce:800">
+  </label>
+</template>

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -53,6 +53,15 @@
       required.bind="required"></schema-editor-number>
   </div>
 
+  <div if.bind="getType(schema) === 'color'" class="schema-editor-block">
+    <require from="./schema-editor-color.html"></require>
+    <schema-editor-color
+      schema.bind="schema"
+      data.two-way="data"
+      change.bind="change"
+      required.bind="required"></schema-editor-color>
+  </div>
+
   <div if.bind="getType(schema) === 'object'" class="schema-editor-block">
     <require from="./schema-editor-object"></require>
     <schema-editor-object


### PR DESCRIPTION
Looks like that: 
<img width="679" alt="screen shot 2017-03-31 at 13 50 02" src="https://cloud.githubusercontent.com/assets/4837884/24549306/fee69252-1618-11e7-87c5-162e5d8d170f.png">

In tool schema `"Q:type": "color"` has to be specified.
