### PR TITLE
feat: select option to show radiobuttons instead of dropdown

### DIFF
--- a/client/src/elements/item-preview/item-preview.html
+++ b/client/src/elements/item-preview/item-preview.html
@@ -3,8 +3,8 @@
   <require from="./item-preview.css"></require>
   <require from="../molecules/radio-button-group"></require>
 
-  <form class="q-form item-preview__settings">
-    <div>
+  <form class="item-preview__settings">
+    <div class="q-form">
       <label class="q-text-small q-text--light"><span t="general.previewTargetLabel"></span>
         <select value.bind="targetProxy.target">
           <option repeat.for="target of availableTargets" model.bind="target">${target.label}</option>

--- a/client/src/elements/molecules/radio-button-group.css
+++ b/client/src/elements/molecules/radio-button-group.css
@@ -1,8 +1,4 @@
 radio-button-group {
-  display: block;
-}
-
-radio-button-group radiogroup {
   width: 100%;
   display: flex;
   flex-direction: row;

--- a/client/src/elements/molecules/radio-button-group.html
+++ b/client/src/elements/molecules/radio-button-group.html
@@ -1,11 +1,9 @@
 <template bindable="options, value">
   <require from="./radio-button-group.css"></require>
-  <radiogroup>
-    <div class="radio-button-group__option" repeat.for="option of options">
-      <input type="radio" id="button-${option.value}" value.bind="option.value" checked.bind="value" matcher.bind="valueMatcher">
-      <label for="button-${option.value}">
-        <compose if.bind="option.icon" view="icons/icon-${option.icon}.html"></compose>
-      </label>
-    </div>
-  </radiogroup>
+  <div class="radio-button-group__option" repeat.for="option of options">
+    <input type="radio" id="button-${option.value}" value.bind="option.value" checked.bind="value" matcher.bind="valueMatcher">
+    <label for="button-${option.value}">
+      <compose if.bind="option.icon" view="icons/icon-${option.icon}.html"></compose>
+    </label>
+  </div>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-select.html
+++ b/client/src/elements/schema-editor/schema-editor-select.html
@@ -1,8 +1,14 @@
 <template>
   <label>
     ${schema["title"]}
-    <select value.bind="data" change.delegate="change()">
+    <select value.bind="data" change.delegate="change()" if.bind="selectType === 'select'">
       <option repeat.for="option of schema.enum" model.bind="option">${optionLabels[$index]}</option>
     </select>
+    <div if.bind="selectType === 'radio'">
+      <div repeat.for="option of schema.enum">
+        <input id="option-${option}" type="radio" name.bind="$parent.schema.title" model.bind="option" checked.bind="$parent.data" change.delegate="change()"></input>
+        <label for="option-${option}">${optionLabels[$index]}</label>
+      </div>
+    </div>
   </label>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-select.js
+++ b/client/src/elements/schema-editor/schema-editor-select.js
@@ -12,6 +12,11 @@ export class SchemaEditorSelect {
     } else {
       this.optionLabels = schema.enum;
     }
+    if (schema['Q:options'] && schema['Q:options'].selectType === 'radio') {
+      this.selectType = 'radio';
+    } else {
+      this.selectType = 'select';
+    }
   }
 
 }

--- a/client/src/styles/q-form.css
+++ b/client/src/styles/q-form.css
@@ -129,3 +129,55 @@
   transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
   transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
 }
+
+/*
+
+  radio
+
+*/
+.q-form input[type="radio"] {
+  opacity: 0;
+  position: absolute;
+  margin: 0px;
+  padding: 0px;
+  width: 0px;
+  height: 2em;
+}
+
+.q-form input[type="radio"] + label {
+  line-height: 2em;
+  position: relative;
+  display: flex;
+  flex-flow: row nowrap;
+  transition: color 0.2s ease-out;
+  align-items: center;
+  cursor: pointer;
+}
+
+.q-form input[type="radio"] + label::before {
+  content: '';
+  width: 1.4em;
+  height: 1.4em;
+  margin-right: 5px;
+  position: relative;
+  background-color: var(--q-color-gray-2);
+  border: 1px solid var(--q-color-gray-5);
+  border-radius: 50%;
+  transition: background-color 0.2s ease-out;
+  cursor: pointer;
+}
+
+.q-form input[type="radio"] + label:hover::before {
+  border-color: var(--q-color-primary-5);
+  background-color: var(--q-color-primary-1);
+}
+
+.q-form input[type="radio"]:checked + label::before {
+  background-color: var(--q-color-primary-5);
+  border-color: var(--q-color-primary-5);
+}
+
+
+.q-form input[type="radio"]:active + label::before, .q-form input[type="radio"]:focus + label::before {
+  box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
```
"type": "string",
"enum": ["a", "b"],
"Q:options": {
  "selectType": "radio"
}
```
results in radio buttons instead of select element.