### PR TITLE
Feat dynamic availability and enum

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -6,35 +6,36 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
+
   map: {
-    "ajv": "npm:ajv@4.11.5",
+    "ajv": "npm:ajv@4.11.8",
     "array2d": "npm:array2d@0.0.5",
-    "aurelia-animator-css": "npm:aurelia-animator-css@1.0.1",
-    "aurelia-binding": "npm:aurelia-binding@1.2.0",
+    "aurelia-animator-css": "npm:aurelia-animator-css@1.0.2",
+    "aurelia-binding": "npm:aurelia-binding@1.2.1",
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.1",
-    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
-    "aurelia-dialog": "npm:aurelia-dialog@1.0.0-beta.3.0.1",
+    "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
+    "aurelia-dialog": "npm:aurelia-dialog@1.0.0-rc.1.0.3",
     "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
-    "aurelia-fetch-client": "npm:aurelia-fetch-client@1.1.1",
-    "aurelia-framework": "npm:aurelia-framework@1.1.0",
+    "aurelia-fetch-client": "npm:aurelia-fetch-client@1.1.2",
+    "aurelia-framework": "npm:aurelia-framework@1.1.2",
     "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0",
-    "aurelia-i18n": "npm:aurelia-i18n@1.3.2",
+    "aurelia-i18n": "npm:aurelia-i18n@1.6.0",
     "aurelia-loader": "npm:aurelia-loader@1.0.0",
-    "aurelia-loader-default": "npm:aurelia-loader-default@1.0.1",
-    "aurelia-logging": "npm:aurelia-logging@1.3.0",
+    "aurelia-loader-default": "npm:aurelia-loader-default@1.0.2",
+    "aurelia-logging": "npm:aurelia-logging@1.3.1",
     "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0",
     "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
     "aurelia-pal": "npm:aurelia-pal@1.3.0",
-    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.1.0",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.2.1",
     "aurelia-path": "npm:aurelia-path@1.1.1",
-    "aurelia-polyfills": "npm:aurelia-polyfills@1.2.0",
-    "aurelia-router": "npm:aurelia-router@1.2.1",
+    "aurelia-polyfills": "npm:aurelia-polyfills@1.2.1",
+    "aurelia-router": "npm:aurelia-router@1.3.0",
     "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
-    "aurelia-templating": "npm:aurelia-templating@1.3.0",
+    "aurelia-templating": "npm:aurelia-templating@1.4.2",
     "aurelia-templating-binding": "npm:aurelia-templating-binding@1.3.0",
-    "aurelia-templating-resources": "npm:aurelia-templating-resources@1.3.1",
+    "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
     "aurelia-templating-router": "npm:aurelia-templating-router@1.1.0",
-    "aurelia-testing": "npm:aurelia-testing@1.0.0-beta.3.0.0",
+    "aurelia-testing": "npm:aurelia-testing@1.0.0-beta.3.0.1",
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.7",
@@ -71,7 +72,7 @@ System.config({
     "github:jspm/nodelibs-vm@0.1.0": {
       "vm-browserify": "npm:vm-browserify@0.0.4"
     },
-    "npm:ajv@4.11.5": {
+    "npm:ajv@4.11.8": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.1",
       "co": "npm:co@4.6.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
@@ -93,74 +94,75 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2",
       "util": "npm:util@0.10.3"
     },
-    "npm:aurelia-animator-css@1.0.1": {
+    "npm:aurelia-animator-css@1.0.2": {
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0"
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
-    "npm:aurelia-binding@1.2.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+    "npm:aurelia-binding@1.2.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0"
     },
     "npm:aurelia-bootstrapper@1.0.1": {
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
-      "aurelia-framework": "npm:aurelia-framework@1.1.0",
+      "aurelia-framework": "npm:aurelia-framework@1.1.2",
       "aurelia-history": "npm:aurelia-history@1.0.0",
       "aurelia-history-browser": "npm:aurelia-history-browser@1.0.0",
-      "aurelia-loader-default": "npm:aurelia-loader-default@1.0.1",
+      "aurelia-loader-default": "npm:aurelia-loader-default@1.0.2",
       "aurelia-logging-console": "npm:aurelia-logging-console@1.0.0",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
-      "aurelia-pal-browser": "npm:aurelia-pal-browser@1.1.0",
-      "aurelia-polyfills": "npm:aurelia-polyfills@1.2.0",
-      "aurelia-router": "npm:aurelia-router@1.2.1",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0",
+      "aurelia-pal-browser": "npm:aurelia-pal-browser@1.2.1",
+      "aurelia-polyfills": "npm:aurelia-polyfills@1.2.1",
+      "aurelia-router": "npm:aurelia-router@1.3.0",
+      "aurelia-templating": "npm:aurelia-templating@1.4.2",
       "aurelia-templating-binding": "npm:aurelia-templating-binding@1.3.0",
-      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.3.1",
+      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
       "aurelia-templating-router": "npm:aurelia-templating-router@1.1.0"
     },
-    "npm:aurelia-dependency-injection@1.3.0": {
+    "npm:aurelia-dependency-injection@1.3.1": {
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
     },
-    "npm:aurelia-dialog@1.0.0-beta.3.0.1": {
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
+    "npm:aurelia-dialog@1.0.0-rc.1.0.3": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0"
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
     "npm:aurelia-event-aggregator@1.0.1": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.0"
+      "aurelia-logging": "npm:aurelia-logging@1.3.1"
     },
-    "npm:aurelia-framework@1.1.0": {
-      "aurelia-binding": "npm:aurelia-binding@1.2.0",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
+    "npm:aurelia-framework@1.1.2": {
+      "aurelia-binding": "npm:aurelia-binding@1.2.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0"
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
     "npm:aurelia-history-browser@1.0.0": {
       "aurelia-history": "npm:aurelia-history@1.0.0",
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
     },
-    "npm:aurelia-i18n@1.3.2": {
-      "aurelia-binding": "npm:aurelia-binding@1.2.0",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
+    "npm:aurelia-i18n@1.6.0": {
+      "aurelia-binding": "npm:aurelia-binding@1.2.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0",
-      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.3.1",
+      "aurelia-templating": "npm:aurelia-templating@1.4.2",
+      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
       "i18next": "npm:i18next@3.5.2",
       "intl": "npm:intl@1.2.5"
     },
-    "npm:aurelia-loader-default@1.0.1": {
+    "npm:aurelia-loader-default@1.0.2": {
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
@@ -170,25 +172,25 @@ System.config({
       "aurelia-path": "npm:aurelia-path@1.1.1"
     },
     "npm:aurelia-logging-console@1.0.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.3.0"
+      "aurelia-logging": "npm:aurelia-logging@1.3.1"
     },
     "npm:aurelia-metadata@1.0.3": {
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
     },
-    "npm:aurelia-pal-browser@1.1.0": {
+    "npm:aurelia-pal-browser@1.2.1": {
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
     },
-    "npm:aurelia-polyfills@1.2.0": {
+    "npm:aurelia-polyfills@1.2.1": {
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
     },
     "npm:aurelia-route-recognizer@1.1.0": {
       "aurelia-path": "npm:aurelia-path@1.1.1"
     },
-    "npm:aurelia-router@1.2.1": {
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
+    "npm:aurelia-router@1.3.0": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
       "aurelia-history": "npm:aurelia-history@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.1.0"
     },
@@ -196,47 +198,47 @@ System.config({
       "aurelia-pal": "npm:aurelia-pal@1.3.0"
     },
     "npm:aurelia-templating-binding@1.3.0": {
-      "aurelia-binding": "npm:aurelia-binding@1.2.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0"
+      "aurelia-binding": "npm:aurelia-binding@1.2.1",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
-    "npm:aurelia-templating-resources@1.3.1": {
-      "aurelia-binding": "npm:aurelia-binding@1.2.0",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
+    "npm:aurelia-templating-resources@1.4.0": {
+      "aurelia-binding": "npm:aurelia-binding@1.2.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0"
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
     "npm:aurelia-templating-router@1.1.0": {
-      "aurelia-binding": "npm:aurelia-binding@1.2.0",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+      "aurelia-binding": "npm:aurelia-binding@1.2.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
-      "aurelia-router": "npm:aurelia-router@1.2.1",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0"
+      "aurelia-router": "npm:aurelia-router@1.3.0",
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
-    "npm:aurelia-templating@1.3.0": {
-      "aurelia-binding": "npm:aurelia-binding@1.2.0",
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
+    "npm:aurelia-templating@1.4.2": {
+      "aurelia-binding": "npm:aurelia-binding@1.2.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
       "aurelia-loader": "npm:aurelia-loader@1.0.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
       "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.2.0"
     },
-    "npm:aurelia-testing@1.0.0-beta.3.0.0": {
-      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.0",
-      "aurelia-framework": "npm:aurelia-framework@1.1.0",
-      "aurelia-logging": "npm:aurelia-logging@1.3.0",
+    "npm:aurelia-testing@1.0.0-beta.3.0.1": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
+      "aurelia-framework": "npm:aurelia-framework@1.1.2",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
-      "aurelia-templating": "npm:aurelia-templating@1.3.0"
+      "aurelia-templating": "npm:aurelia-templating@1.4.2"
     },
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"

--- a/client/src/elements/schema-editor/helpers.js
+++ b/client/src/elements/schema-editor/helpers.js
@@ -1,3 +1,24 @@
+function hasEnum(schema) {
+  if (schema.hasOwnProperty('enum')) {
+    return true;
+  }
+  if (schema['Q:options'] && schema['Q:options'].hasOwnProperty('dynamicEnum')) {
+    return true;
+  }
+  return false;
+}
+
+function hasType(schema, type) {
+  if (schema.hasOwnProperty('anyOf')) {
+    for (let anyOfType of schema.anyOf) {
+      if (anyOfType === type) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function getType(schema) {
   let type;
 
@@ -8,11 +29,11 @@ export function getType(schema) {
     type = schema['Q:type'];
   }
 
-  if (type === 'string' && schema.enum) {
+  if ((type === 'string' || hasType(schema, 'string')) && hasEnum(schema)) {
     type = 'select';
   }
 
-  if (type === 'number' && schema.enum) {
+  if ((type === 'number' || hasType(schema, 'number')) && hasEnum(schema)) {
     type = 'select';
   }
 

--- a/client/src/elements/schema-editor/schema-editor-array.html
+++ b/client/src/elements/schema-editor/schema-editor-array.html
@@ -2,6 +2,9 @@
   <require from="./schema-editor-wrapper"></require>
   <require from="./schema-editor-array.css"></require>
   <require from="../molecules/delete-button.html"></require>
+  <legend>
+    ${schema.title}
+  </legend>
   <div if.bind="data" repeat.for="entry of data" class="schema-editor-array__entry">
     <div class="schema-editor-array__collapsecontrol" if.bind="options.expandable">
       <button-secondary icon="expand" size="small" if.bind="collapsedStates[$index] !== 'expanded'" click.delegate="expand($index)"></button-secondary>

--- a/client/src/elements/schema-editor/schema-editor-array.html
+++ b/client/src/elements/schema-editor/schema-editor-array.html
@@ -23,7 +23,8 @@
         if.bind="collapsedStates[$index] === 'expanded' || !options.expandable"
         schema.bind="$parent.getSchemaForArrayEntry(data[$index])"
         data.two-way="data[$index]"
-        change.bind="$parent.handleChange">
+        change.bind="$parent.handleChange"
+        no-object-title="true">
     </schema-editor-wrapper>
     <div class="schema-editor-array__entry-actions" if.bind="!options.expandable">
       <button-tertiary if.bind="!$first" icon="up" click.delegate="moveElementUp(data, $index)" size="small"></button-tertiary>

--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -1,12 +1,12 @@
 import { bindable, computedFrom, LogManager } from 'aurelia-framework';
-const log = LogManager.getLogger('Q');
-
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 import Ajv from 'ajv';
 import generateFromSchema from 'helpers/generateFromSchema.js';
 
-
+const log = LogManager.getLogger('Q');
 const ajv = new Ajv();
 
+@checkAvailability()
 export class SchemaEditorArray {
 
   @bindable schema;

--- a/client/src/elements/schema-editor/schema-editor-base64image.js
+++ b/client/src/elements/schema-editor/schema-editor-base64image.js
@@ -1,5 +1,7 @@
 import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 
+@checkAvailability()
 export class SchemaEditorBase64image {
 
   @bindable schema;

--- a/client/src/elements/schema-editor/schema-editor-boolean.html
+++ b/client/src/elements/schema-editor/schema-editor-boolean.html
@@ -1,4 +1,4 @@
-<template class="schema-editor-input" bindable="schema, data, change">
+<template class="schema-editor-input">
   <div class="q-form__checkbox">
     <label>
       <input type="checkbox" checked.bind="data" change.delegate="change()">

--- a/client/src/elements/schema-editor/schema-editor-boolean.js
+++ b/client/src/elements/schema-editor/schema-editor-boolean.js
@@ -1,0 +1,11 @@
+import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+
+@checkAvailability()
+export class SchemaEditorBoolean {
+
+  @bindable schema;
+  @bindable data;
+  @bindable change;
+
+}

--- a/client/src/elements/schema-editor/schema-editor-color.html
+++ b/client/src/elements/schema-editor/schema-editor-color.html
@@ -1,4 +1,4 @@
-<template class="schema-editor-input" bindable="schema, data, change, required">
+<template class="schema-editor-input">
   <require from="./schema-editor-color.css"></require>
   <label>
     ${schema["title"]}

--- a/client/src/elements/schema-editor/schema-editor-color.js
+++ b/client/src/elements/schema-editor/schema-editor-color.js
@@ -1,0 +1,12 @@
+import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+
+@checkAvailability()
+export class SchemaEditorColor {
+
+  @bindable schema;
+  @bindable data;
+  @bindable change;
+  @bindable required;
+
+}

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.js
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.js
@@ -1,12 +1,12 @@
 import { bindable, inject, Loader, LogManager } from 'aurelia-framework';
-
-const log = LogManager.getLogger('Q');
-
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 import qEnv from 'resources/qEnv';
 import QConfig from 'resources/QConfig';
 
+const log = LogManager.getLogger('Q');
 const iconPinSvg = '<svg viewBox="0 0 52 52"><path d="M31.5,35.5 M20.5,16.5 M20.5,35.5 M31.5,16.5 M30,18c0-2.2-1.8-4-4-4s-4,1.8-4,4c0,1.9,1.3,3.4,3,3.9V38h1h1V21.9C28.7,21.4,30,19.9,30,18z"/></svg>';
 
+@checkAvailability()
 @inject(QConfig, Loader)
 export class SchemaEditorGeojsonPoint {
 

--- a/client/src/elements/schema-editor/schema-editor-json.js
+++ b/client/src/elements/schema-editor/schema-editor-json.js
@@ -1,8 +1,10 @@
 import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 import Ajv from 'ajv';
 
 const ajv = new Ajv();
 
+@checkAvailability()
 export class SchemaEditorJson {
 
   @bindable schema;

--- a/client/src/elements/schema-editor/schema-editor-lat-lng.js
+++ b/client/src/elements/schema-editor/schema-editor-lat-lng.js
@@ -1,11 +1,12 @@
 import { bindable, inject, Loader, LogManager } from 'aurelia-framework';
-const log = LogManager.getLogger('Q');
-
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 import qEnv from 'resources/qEnv';
 import QConfig from 'resources/QConfig';
 
 const iconPinSvg = '<svg viewBox="0 0 52 52"><path d="M31.5,35.5 M20.5,16.5 M20.5,35.5 M31.5,16.5 M30,18c0-2.2-1.8-4-4-4s-4,1.8-4,4c0,1.9,1.3,3.4,3,3.9V38h1h1V21.9C28.7,21.4,30,19.9,30,18z"/></svg>';
+const log = LogManager.getLogger('Q');
 
+@checkAvailability()
 @inject(QConfig, Loader)
 export class SchemaEditorLatLng {
 

--- a/client/src/elements/schema-editor/schema-editor-link.js
+++ b/client/src/elements/schema-editor/schema-editor-link.js
@@ -1,5 +1,7 @@
 import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 
+@checkAvailability()
 export class SchemaEditorLink {
 
   @bindable data

--- a/client/src/elements/schema-editor/schema-editor-number.js
+++ b/client/src/elements/schema-editor/schema-editor-number.js
@@ -1,5 +1,7 @@
 import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 
+@checkAvailability()
 export class SchemaEditorNumber {
 
   @bindable data

--- a/client/src/elements/schema-editor/schema-editor-object.html
+++ b/client/src/elements/schema-editor/schema-editor-object.html
@@ -2,18 +2,17 @@
     <require from="./schema-editor-wrapper"></require>
 
     <div if.bind="schema.properties" repeat.for="propertyName of schema.properties | keys">
-
       <fieldset if.bind="getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array'" class="${isCompact($parent.schema.properties[propertyName]) ? 'compact' : ''}">
-        <legend>
-          ${$parent.schema.properties[propertyName]['title']}
+        <legend if.bind="getType($parent.schema.properties[propertyName]) === 'object'">
+          ${$parent.schema.properties[propertyName].title}
         </legend>
-
         <schema-editor-wrapper
             if.bind="!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor"
             schema.bind="$parent.schema.properties[propertyName]"
             data.two-way="$parent.data[propertyName]"
             change.bind="$parent.change"
-            required.bind="isRequired($parent.schema, propertyName)">
+            required.bind="isRequired($parent.schema, propertyName)"
+            is-available.bind="$parent.isAvailable">
         </schema-editor-wrapper>
       </fieldset>
 
@@ -22,7 +21,8 @@
         schema.bind="$parent.schema.properties[propertyName]"
         data.two-way="$parent.data[propertyName]"
         change.bind="$parent.change"
-        required.bind="isRequired($parent.schema, propertyName)">
+        required.bind="isRequired($parent.schema, propertyName)"
+        is-available.bind="$parent.isAvailable">
       </schema-editor-wrapper>
 
     </div>

--- a/client/src/elements/schema-editor/schema-editor-object.html
+++ b/client/src/elements/schema-editor/schema-editor-object.html
@@ -1,18 +1,16 @@
 <template>
     <require from="./schema-editor-wrapper"></require>
-
+    <legend if.bind="!noObjectTitle">
+      ${schema.title}
+    </legend>
     <div if.bind="schema.properties" repeat.for="propertyName of schema.properties | keys">
-      <fieldset if.bind="getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array'" class="${isCompact($parent.schema.properties[propertyName]) ? 'compact' : ''}">
-        <legend if.bind="getType($parent.schema.properties[propertyName]) === 'object'">
-          ${$parent.schema.properties[propertyName].title}
-        </legend>
+      <fieldset if.bind="noFieldsets || getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array'" class="${isCompact($parent.schema.properties[propertyName]) ? 'compact' : ''}">
         <schema-editor-wrapper
             if.bind="!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor"
             schema.bind="$parent.schema.properties[propertyName]"
             data.two-way="$parent.data[propertyName]"
             change.bind="$parent.change"
-            required.bind="isRequired($parent.schema, propertyName)"
-            is-available.bind="$parent.isAvailable">
+            required.bind="isRequired($parent.schema, propertyName)">
         </schema-editor-wrapper>
       </fieldset>
 
@@ -21,8 +19,7 @@
         schema.bind="$parent.schema.properties[propertyName]"
         data.two-way="$parent.data[propertyName]"
         change.bind="$parent.change"
-        required.bind="isRequired($parent.schema, propertyName)"
-        is-available.bind="$parent.isAvailable">
+        required.bind="isRequired($parent.schema, propertyName)">
       </schema-editor-wrapper>
 
     </div>

--- a/client/src/elements/schema-editor/schema-editor-object.js
+++ b/client/src/elements/schema-editor/schema-editor-object.js
@@ -8,6 +8,7 @@ export class SchemaEditorObject {
   @bindable schema;
   @bindable data;
   @bindable change;
+  @bindable noObjectTitle;
 
   constructor() {
     this.getType = getType;

--- a/client/src/elements/schema-editor/schema-editor-object.js
+++ b/client/src/elements/schema-editor/schema-editor-object.js
@@ -1,6 +1,8 @@
-import {bindable} from 'aurelia-framework';
-import {getType} from './helpers.js';
+import { bindable } from 'aurelia-framework';
+import { getType } from './helpers.js';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 
+@checkAvailability()
 export class SchemaEditorObject {
 
   @bindable schema;

--- a/client/src/elements/schema-editor/schema-editor-select.html
+++ b/client/src/elements/schema-editor/schema-editor-select.html
@@ -1,4 +1,4 @@
-<template>
+<template class="schema-editor-input">
   <label>
     ${schema["title"]}
     <select value.bind="data" change.delegate="change()" if.bind="selectType === 'select'">

--- a/client/src/elements/schema-editor/schema-editor-select.js
+++ b/client/src/elements/schema-editor/schema-editor-select.js
@@ -1,5 +1,9 @@
 import { bindable } from 'aurelia-framework';
+import { resolveDynamicEnum } from 'resources/schemaEditorDecorators.js';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 
+@checkAvailability()
+@resolveDynamicEnum()
 export class SchemaEditorSelect {
 
   @bindable schema;

--- a/client/src/elements/schema-editor/schema-editor-string.html
+++ b/client/src/elements/schema-editor/schema-editor-string.html
@@ -1,4 +1,4 @@
-<template class="schema-editor-input" bindable="schema, data, change, required">
+<template class="schema-editor-input">
   <label>
     ${schema["title"]}
     <input type="text" value.bind="data" required.bind="required" keyup.delegate="change() & debounce:800">

--- a/client/src/elements/schema-editor/schema-editor-string.js
+++ b/client/src/elements/schema-editor/schema-editor-string.js
@@ -1,0 +1,12 @@
+import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+
+@checkAvailability()
+export class SchemaEditorString {
+
+  @bindable schema;
+  @bindable data;
+  @bindable change;
+  @bindable required;
+
+}

--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -1,4 +1,5 @@
 import { bindable, inject, Loader } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
 import array2d from 'array2d';
 
 function hasNonNullInArray(arr) {
@@ -37,6 +38,7 @@ function emptyToNull(data) {
   return data;
 }
 
+@checkAvailability()
 @inject(Loader)
 export class SchemaEditorTable {
 

--- a/client/src/elements/schema-editor/schema-editor-textarea.html
+++ b/client/src/elements/schema-editor/schema-editor-textarea.html
@@ -1,4 +1,4 @@
-<template class="schema-editor-input" bindable="schema, data, change, required">
+<template class="schema-editor-input">
   <label>
     ${schema["title"]}
     <textare value.bind="data" required.bind="required" input.delegate="change() & debounce:800"></textare>

--- a/client/src/elements/schema-editor/schema-editor-textarea.js
+++ b/client/src/elements/schema-editor/schema-editor-textarea.js
@@ -1,0 +1,12 @@
+import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+
+@checkAvailability()
+export class SchemaEditorTextarea {
+
+  @bindable schema;
+  @bindable data;
+  @bindable change;
+  @bindable required;
+
+}

--- a/client/src/elements/schema-editor/schema-editor-url.html
+++ b/client/src/elements/schema-editor/schema-editor-url.html
@@ -1,4 +1,4 @@
-<template bindable="schema, data, change, required">
+<template>
   <label>
     ${schema["title"]}
     <input type="url" required.bind="required" value.bind="data" keyup.delegate="change() & debounce:800">

--- a/client/src/elements/schema-editor/schema-editor-url.js
+++ b/client/src/elements/schema-editor/schema-editor-url.js
@@ -1,0 +1,12 @@
+import { bindable } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+
+@checkAvailability()
+export class SchemaEditorUrl {
+
+  @bindable schema;
+  @bindable data;
+  @bindable change;
+  @bindable required;
+
+}

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -1,7 +1,14 @@
 <template style="display: block;">
+  <div if.bind="getType(schema) === 'object'" class="schema-editor-block">
+    <require from="./schema-editor-object"></require>
+    <schema-editor-object
+      schema.bind="schema"
+      data.two-way="data"
+      change.bind="change"></schema-editor-object>
+  </div>
 
   <div if.bind="getType(schema) === 'string'" class="schema-editor-block">
-    <require from="./schema-editor-string.html"></require>
+    <require from="./schema-editor-string"></require>
     <schema-editor-string
       schema.bind="schema"
       data.two-way="data"
@@ -10,7 +17,7 @@
   </div>
 
   <div if.bind="getType(schema) === 'textarea'" class="schema-editor-block">
-    <require from="./schema-editor-textarea.html"></require>
+    <require from="./schema-editor-textarea"></require>
     <schema-editor-textarea
       schema.bind="schema"
       data.two-way="data"
@@ -19,7 +26,7 @@
   </div>
 
   <div if.bind="getType(schema) === 'boolean'" class="schema-editor-block">
-    <require from="./schema-editor-boolean.html"></require>
+    <require from="./schema-editor-boolean"></require>
     <schema-editor-boolean
       schema.bind="schema"
       data.two-way="data"
@@ -27,7 +34,7 @@
   </div>
 
   <div if.bind="getType(schema) === 'url'" class="schema-editor-block">
-    <require from="./schema-editor-url.html"></require>
+    <require from="./schema-editor-url"></require>
     <schema-editor-url
       schema.bind="schema"
       data.two-way="data"
@@ -54,20 +61,12 @@
   </div>
 
   <div if.bind="getType(schema) === 'color'" class="schema-editor-block">
-    <require from="./schema-editor-color.html"></require>
+    <require from="./schema-editor-color"></require>
     <schema-editor-color
       schema.bind="schema"
       data.two-way="data"
       change.bind="change"
       required.bind="required"></schema-editor-color>
-  </div>
-
-  <div if.bind="getType(schema) === 'object'" class="schema-editor-block">
-    <require from="./schema-editor-object"></require>
-    <schema-editor-object
-      schema.bind="schema"
-      data.two-way="data"
-      change.bind="change"></schema-editor-object>
   </div>
 
   <div if.bind="getType(schema) === 'array'" class="schema-editor-block">
@@ -130,5 +129,4 @@
       change.bind="change"
       required.bind="required"></schema-editor-table>
   </div>
-
 </template>

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -4,7 +4,8 @@
     <schema-editor-object
       schema.bind="schema"
       data.two-way="data"
-      change.bind="change"></schema-editor-object>
+      change.bind="change"
+      no-object-title.bind="noObjectTitle"></schema-editor-object>
   </div>
 
   <div if.bind="getType(schema) === 'string'" class="schema-editor-block">

--- a/client/src/elements/schema-editor/schema-editor-wrapper.js
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.js
@@ -7,6 +7,7 @@ export class SchemaEditorWrapper {
   @bindable data;
   @bindable change;
   @bindable required;
+  @bindable noObjectTitle;
 
   constructor() {
     this.getType = getType;

--- a/client/src/elements/schema-editor/schema-editor.css
+++ b/client/src/elements/schema-editor/schema-editor.css
@@ -5,15 +5,19 @@ schema-editor {
 schema-editor fieldset {
   border: none;
   padding: 0;
+  margin: 0;
+}
+
+schema-editor fieldset > schema-editor-wrapper {
   margin: calc(var(--q-space-base) * 2) 0 calc(var(--q-space-base) / 2) 0;
 }
 
-schema-editor fieldset fieldset {
+schema-editor fieldset fieldset > schema-editor-wrapper {
   padding: 0 0 0 20px;
   margin: calc(var(--q-space-base) * 2) 0 calc(var(--q-space-base) / 2) 0;
 }
 
-schema-editor fieldset fieldset.compact {
+schema-editor fieldset fieldset.compact > schema-editor-wrapper {
   padding: 0 0 0 10px;
   margin-top: calc(var(--q-space-base) / 2);
 }

--- a/client/src/elements/schema-editor/schema-editor.html
+++ b/client/src/elements/schema-editor/schema-editor.html
@@ -5,6 +5,7 @@
   <schema-editor-wrapper
       schema.bind="schema"
       data.two-way="data"
-      change.bind="change">
+      change.bind="change"
+      no-object-title="true">
   </schema-editor-wrapper>
 </template>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -13,6 +13,8 @@ import EmbedCodeGenerator from 'resources/EmbedCodeGenerator.js';
 import ItemStore from 'resources/ItemStore.js';
 import Statistics from 'resources/Statistics.js';
 import ToolsInfo from 'resources/ToolsInfo.js';
+import SchemaEditorInputAvailabilityChecker from 'resources/SchemaEditorInputAvailabilityChecker.js';
+import ToolEndpointChecker from 'resources/ToolEndpointChecker.js';
 import qEnv from 'resources/qEnv.js';
 import { registerEastereggs } from 'eastereggs.js';
 
@@ -27,6 +29,8 @@ export async function configure(aurelia) {
   aurelia.use.singleton(MessageService);
   aurelia.use.singleton(QTargets);
   aurelia.use.singleton(ToolsInfo);
+  aurelia.use.singleton(ToolEndpointChecker);
+  aurelia.use.singleton(SchemaEditorInputAvailabilityChecker);
   aurelia.use.singleton(User);
 
   aurelia.use

--- a/client/src/pages/editor.css
+++ b/client/src/pages/editor.css
@@ -37,3 +37,24 @@
 .editor main::-webkit-scrollbar-thumb {
   background: var(--q-color-gray-5);
 }
+
+.editor__options {
+  --q-h1-size: 13px;
+  --q-h2-size: 13px;
+  --q-h3-size: 13px;
+  --q-h4-size: 13px;
+  --q-h5-size: 13px;
+  --q-h6-size: 13px;
+}
+
+.editor__options legend {
+  border-bottom: 1px solid var(--q-color-gray-4);
+  color: var(--q-text-light-color);
+  margin-bottom: calc(var(--q-space-base) / 4);
+}
+
+
+/* make the options more compact by removing the margin around fieldsets */
+.editor__options fieldset > schema-editor-wrapper {
+  margin: 0 !important;
+}

--- a/client/src/pages/editor.js
+++ b/client/src/pages/editor.js
@@ -11,6 +11,8 @@ import { ConfirmDialog } from 'dialogs/confirm-dialog.js';
 import qEnv from 'resources/qEnv.js';
 import MessageService from 'resources/MessageService.js';
 import ItemStore from 'resources/ItemStore.js';
+import ToolEndpointChecker from 'resources/ToolEndpointChecker.js';
+
 import generateFromSchema from 'helpers/generateFromSchema.js';
 
 function getSchemaForSchemaEditor(schema) {
@@ -48,19 +50,22 @@ function getTranslatedSchema(schema, toolName, i18n) {
   return schema;
 }
 
-@inject(ItemStore, MessageService, DialogService, I18N, EventAggregator, TaskQueue)
+@inject(ItemStore, MessageService, ToolEndpointChecker, DialogService, I18N, EventAggregator, TaskQueue)
 export class Editor {
 
-  constructor(itemStore, messageService, dialogService, i18n, eventAggregator, taskQueue) {
+  constructor(itemStore, messageService, toolEndpointChecker, dialogService, i18n, eventAggregator, taskQueue) {
     this.itemStore = itemStore;
     this.messageService = messageService;
+    this.toolEndpointChecker = toolEndpointChecker;
     this.dialogService = dialogService;
     this.i18n = i18n;
     this.eventAggregator = eventAggregator;
     this.taskQueue = taskQueue;
   }
 
-  activate(routeParams) {
+  async activate(routeParams) {
+    this.toolName = routeParams.tool;
+
     let showMessageTimeout;
     let timeoutPromise = new Promise((resolve, reject) => {
       showMessageTimeout = setTimeout(() => {
@@ -68,10 +73,9 @@ export class Editor {
         reject(new Error('activating editor takes too long'));
       }, 5000);
     });
-    let allLoaded = qEnv.QServerBaseUrl
-      .then(QServerBaseUrl => {
-        return fetch(`${QServerBaseUrl}/tools/${routeParams.tool}/schema.json`);
-      })
+
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
+    let allLoaded = fetch(`${QServerBaseUrl}/tools/${this.toolName}/schema.json`)
       .then(response => {
         if (response.ok) {
           return response.json();
@@ -80,11 +84,11 @@ export class Editor {
       })
       .then(schema => {
         this.fullSchema = schema;
-        this.setTranslatedEditorAndOptionsSchema(this.fullSchema, routeParams.tool);
+        this.setTranslatedEditorAndOptionsSchema(this.fullSchema, this.toolName);
 
         // whenever there is a language change, we calculate the schema and translate all title properties
         this.eventAggregator.subscribe('i18n:locale:changed', () => {
-          this.setTranslatedEditorAndOptionsSchema(this.fullSchema, routeParams.tool);
+          this.setTranslatedEditorAndOptionsSchema(this.fullSchema, this.toolName);
         });
       })
       .then(() => {
@@ -94,11 +98,16 @@ export class Editor {
 
         let item = this.itemStore.getNewItem();
         item.conf = generateFromSchema(this.fullSchema);
-        item.conf.tool = routeParams.tool;
+        item.conf.tool = this.toolName;
         return item;
       })
       .then(item => {
         if (item) {
+          // set the toolName and the current item to toolEndpointChecker
+          // whenever we activate the editor. The toolEndpointChecker is used
+          // in the SchemaEditorInputAvailabilityChecker to send requests to the current tool
+          this.toolEndpointChecker.setCurrentToolName(this.toolName);
+          this.toolEndpointChecker.setCurrentItem(item);
           this.item = item;
         }
       });
@@ -171,6 +180,11 @@ export class Editor {
   handleChange() {
     this.taskQueue.queueMicroTask(() => {
       this.item.changed();
+
+      // whenever we have a change in data, we need to reevaluate all the checks
+      // that used the toolEndpoint as the result could be different after data
+      // changes occured.
+      this.toolEndpointChecker.triggerReevaluation();
       this.previewData = JSON.parse(JSON.stringify(this.item.conf));
     });
   }

--- a/client/src/resources/SchemaEditorInputAvailabilityChecker.js
+++ b/client/src/resources/SchemaEditorInputAvailabilityChecker.js
@@ -1,0 +1,66 @@
+import { inject } from 'aurelia-framework';
+import ToolEndpointChecker from 'resources/ToolEndpointChecker.js';
+
+@inject(ToolEndpointChecker)
+export default class SchemaEditorInputAvailabilityChecker {
+
+  constructor(toolEndpointChecker) {
+    this.toolEndpointChecker = toolEndpointChecker;
+  }
+
+  registerReevaluateCallback(cb) {
+    return this.toolEndpointChecker.registerReevaluateCallback(cb);
+  }
+
+  unregisterReevaluateCallback(id) {
+    return this.toolEndpointChecker.unregisterReevaluateCallback(id);
+  }
+
+  hasAvailabilityCheck(schema) {
+    if (!schema.hasOwnProperty('Q:options')) {
+      return false;
+    }
+    if (!schema['Q:options']) {
+      return false;
+    }
+    if (!Array.isArray(schema['Q:options'].availabilityChecks)) {
+      return false;
+    }
+    if (schema['Q:options'].availabilityChecks.length < 1) {
+      return false;
+    }
+    return true;
+  }
+
+  async isAvailable(schema) {
+    try {
+      if (!this.hasAvailabilityCheck(schema)) {
+        return true;
+      }
+      let checkPromises = [];
+      for (let availabilityCheck of schema['Q:options'].availabilityChecks) {
+        if (availabilityCheck.type === 'toolEndpoint') {
+          checkPromises.push(this.checkToolEndpoint(availabilityCheck));
+        }
+      }
+      return await Promise.all(checkPromises);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async checkToolEndpoint(availabilityCheck) {
+    if (!availabilityCheck.withData) {
+      const availability = await this.toolEndpointChecker.fetch(availabilityCheck.endpoint);
+      if (availability.available === false) {
+        return Promise.reject('not available: ' + JSON.stringify(availabilityCheck));
+      }
+    } else {
+      const availability = await this.toolEndpointChecker.fetchWithItem(availabilityCheck.endpoint);
+      if (availability.available === false) {
+        return Promise.reject('not available: ' + JSON.stringify(availabilityCheck));
+      }
+    }
+    return true;
+  }
+}

--- a/client/src/resources/ToolEndpointChecker.js
+++ b/client/src/resources/ToolEndpointChecker.js
@@ -1,0 +1,55 @@
+import qEnv from 'resources/qEnv.js';
+
+export default class ToolEndpointChecker {
+
+  reevaluateCallbacks = [];
+
+  setCurrentToolName(toolName) {
+    this.toolName = toolName;
+  }
+
+  setCurrentItem(item) {
+    this.item = item;
+  }
+
+  triggerReevaluation() {
+    for (let cb of this.reevaluateCallbacks) {
+      cb();
+    }
+  }
+
+  registerReevaluateCallback(cb) {
+    this.reevaluateCallbacks.push(cb);
+    return cb;
+  }
+
+  unregisterReevaluateCallback(id) {
+    const index = this.reevaluateCallbacks.indexOf(id);
+    if (index > -1) {
+      this.reevaluateCallbacks.splice(index, 1);
+    }
+  }
+
+  async fetch(endpoint) {
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
+    const toolRequestBaseUrl = `${QServerBaseUrl}/tools/${this.toolName}`;
+    const resp = await fetch(`${toolRequestBaseUrl}/${endpoint}`);
+    if (resp.status !== 200) {
+      throw new Error(resp.statusMessage);
+    }
+    return await resp.json();
+  }
+
+  async fetchWithItem(endpoint) {
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
+    const toolRequestBaseUrl = `${QServerBaseUrl}/tools/${this.toolName}`;
+    const resp = await fetch(`${toolRequestBaseUrl}/${endpoint}`, {
+      method: 'POST',
+      body: JSON.stringify(this.item.conf)
+    });
+    if (resp.status !== 200) {
+      throw new Error(resp.statusMessage);
+    }
+    return await resp.json();
+  }
+}

--- a/client/src/resources/schema-editor-decorators/checkAvailability.js
+++ b/client/src/resources/schema-editor-decorators/checkAvailability.js
@@ -20,6 +20,19 @@ export function checkAvailability() {
       bind(bindingContext, overrideContext) {
         if (super.bind) {
           super.bind(bindingContext, overrideContext);
+        } else {
+          // if we do not have bind implemented in the decorated class, we should call
+          // all the *Changed methods, as aurelia is not doing it for the first change if bind is implemented
+          let parentPrototype = Object.getPrototypeOf(Object.getPrototypeOf(this));          
+          if (!parentPrototype) {
+            return;
+          }
+          for (let prop of Object.getOwnPropertyNames(parentPrototype)) {
+            if (prop.endsWith('Changed')) {
+              let dataprop = prop.slice(0, -7); // 'Changed' has length of 7
+              this[prop](this[dataprop]);
+            }
+          }
         }
 
         this.__reevaluateCallbackId__ = this.__schemaEditorInputAvailabilityChecker__.registerReevaluateCallback(async () => {

--- a/client/src/resources/schema-editor-decorators/checkAvailability.js
+++ b/client/src/resources/schema-editor-decorators/checkAvailability.js
@@ -1,0 +1,57 @@
+import SchemaEditorInputAvailabilityChecker from 'resources/SchemaEditorInputAvailabilityChecker.js';
+
+export function checkAvailability() {
+  return function(target) {
+    // store any already existing inject property to concat it with the Element we want injected
+    let inject = [];
+    if (target.prototype.inject) {
+      inject = target.prototype.inject;
+    }
+
+    return class extends target {
+      static inject = [Element, SchemaEditorInputAvailabilityChecker].concat(inject);
+      constructor(elem, schemaEditorInputAvailabilityChecker, ...rest) {
+        super(...rest);
+        this.__element__ = elem;
+        this.__schemaEditorInputAvailabilityChecker__ = schemaEditorInputAvailabilityChecker;
+        this.__inputElements__ = this.__element__.querySelectorAll('input, textarea, select, button');
+      }
+
+      bind(bindingContext, overrideContext) {
+        if (super.bind) {
+          super.bind(bindingContext, overrideContext);
+        }
+
+        this.__reevaluateCallbackId__ = this.__schemaEditorInputAvailabilityChecker__.registerReevaluateCallback(async () => {
+          this.__checkAvailability__();
+        });
+
+        this.__checkAvailability__();
+      }
+
+      unbind() {
+        if (super.unbind) {
+          super.unbind();
+        }
+        this.__schemaEditorInputAvailabilityChecker__.unregisterReevaluateCallback(this.__reevaluateCallbackId__);
+      }
+
+      async __checkAvailability__() {
+        this.__element__.classList.add('disabled');
+        for (let inputElement of this.__inputElements__) {
+          inputElement.disabled = true;
+        }
+        let isAvailable = await this.__schemaEditorInputAvailabilityChecker__.isAvailable(this.schema);
+        if (isAvailable) {
+          this.__element__.style.display = 'block';
+          this.__element__.classList.remove('disabled');
+          for (let inputElement of this.__inputElements__) {
+            inputElement.disabled = false;
+          }
+        } else {
+          this.__element__.style.display = 'none';
+        }
+      }
+    };
+  };
+}

--- a/client/src/resources/schema-editor-decorators/checkAvailability.js
+++ b/client/src/resources/schema-editor-decorators/checkAvailability.js
@@ -23,7 +23,7 @@ export function checkAvailability() {
         } else {
           // if we do not have bind implemented in the decorated class, we should call
           // all the *Changed methods, as aurelia is not doing it for the first change if bind is implemented
-          let parentPrototype = Object.getPrototypeOf(Object.getPrototypeOf(this));          
+          let parentPrototype = Object.getPrototypeOf(Object.getPrototypeOf(this));
           if (!parentPrototype) {
             return;
           }

--- a/client/src/resources/schema-editor-decorators/resolveDynamicEnum.js
+++ b/client/src/resources/schema-editor-decorators/resolveDynamicEnum.js
@@ -1,0 +1,86 @@
+import ToolEndpointChecker from 'resources/ToolEndpointChecker.js';
+import { Container } from 'aurelia-dependency-injection';
+
+export function resolveDynamicEnum() {
+  return function(target) {
+    let container = (Container.instance || new Container());
+    const toolEndpointChecker = container.get(ToolEndpointChecker);
+    let originalBind;
+    if (target.prototype.bind) {
+      originalBind = target.prototype.bind;
+    }
+
+    let originalUnbind;
+    if (target.prototype.unbind) {
+      originalUnbind = target.prototype.unbind;
+    }
+
+    async function getDynamicEnum(schema) {
+      if (schema['Q:options'].dynamicEnum.type !== 'toolEndpoint') {
+        throw new Error(`${schema['Q:options'].dynamicEnum.type} is not implemented as dynamicEnum type`);
+      }
+      if (schema['Q:options'].dynamicEnum.withData) {
+        return await toolEndpointChecker.fetchWithItem(schema['Q:options'].dynamicEnum.endpoint);
+      }
+      return await toolEndpointChecker.fetch(schema['Q:options'].dynamicEnum.endpoint);
+    }
+
+    async function resolve() {
+      const disabledOrig = this.isDisabled;
+      this.isDisabled = true;
+      try {
+        const dynamicEnum = await getDynamicEnum(this.schema);
+        if (dynamicEnum.hasOwnProperty('enum')) {
+          this.schema.enum = dynamicEnum.enum;
+        }
+        if (dynamicEnum.hasOwnProperty('enum_titles')) {
+          this.schema['Q:options'].enum_titles = dynamicEnum.enum_titles;
+        }
+        if (this.schemaChanged) {
+          this.schemaChanged(this.schema);
+        }
+      } catch (e) {
+        delete this.schema.enum;
+      }
+      this.isDisabled = disabledOrig;
+    }
+
+    let reevaluateCallbackId;
+
+    target.prototype.bind = async function(bindingContext, overrideContext) {
+      // if there is an original bind lifecycle method implemented, call it here
+      if (originalBind) {
+        originalBind.apply(this, [bindingContext, overrideContext]);
+      } else {
+        // otherwise we need to call any *Changed() callback implemented on the bindingContext
+        // as aurelia doesn't call these if the bind method is implemented
+        // and we do not want to alter behaviour of the view model regarding this in this decorator
+        for (let prop of Object.keys(Reflect.getPrototypeOf(bindingContext))) {
+          const callbackName = `${prop}Changed`;
+          if (this[callbackName]) {
+            this[callbackName](bindingContext[prop]);
+          }
+        }
+      }
+
+      if (!this.schema.hasOwnProperty('Q:options') || !this.schema['Q:options'].hasOwnProperty('dynamicEnum')) {
+        return;
+      }
+
+      reevaluateCallbackId = toolEndpointChecker.registerReevaluateCallback(async () => {
+        resolve.apply(this);
+      });
+
+      resolve.apply(this);
+    };
+
+    target.prototype.unbind = function() {
+      // if there is an original unbind lifecycle method implemented, call it here
+      if (originalUnbind) {
+        originalUnbind.apply(this);
+      }
+
+      toolEndpointChecker.unregisterReevaluateCallback(reevaluateCallbackId);
+    };
+  };
+}

--- a/client/src/resources/schemaEditorDecorators.js
+++ b/client/src/resources/schemaEditorDecorators.js
@@ -1,0 +1,2 @@
+export * from './schema-editor-decorators/checkAvailability.js';
+export * from './schema-editor-decorators/resolveDynamicEnum.js';

--- a/client/src/styles/q-form.css
+++ b/client/src/styles/q-form.css
@@ -36,6 +36,12 @@
   box-shadow: 0px 0px 5px 1px var(--q-color-gray-4);
 }
 
+.q-form .disabled,
+.q-form input:disabled,
+.q-form textarea:disabled,
+.q-form select:disabled {
+  opacity: 0.5;
+}
 
 .q-form input[type="text"], 
 .q-form input[type="url"] {
@@ -176,7 +182,6 @@
   background-color: var(--q-color-primary-5);
   border-color: var(--q-color-primary-5);
 }
-
 
 .q-form input[type="radio"]:active + label::before, .q-form input[type="radio"]:focus + label::before {
   box-shadow: 0px 0px 3px 0px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
This introduces two new features configurable from the tool schema.

## dynamicEnum
dynamicEnum allows to implement an endpoint that returns an object like the following in the tool service. If `withData` is `true`, the endpoint needs to accept the item data as a POST payload. The dynamicEnum is reevaluated every time the data changes.
```
{
  enum: ['a', 'b'],
  enum_titles: ['AAA', 'BBB']
}
```

configuration in the schema looks like this:
```
{
  "title": "Hervorhebung",
  "anyOf": ["number", "null"],
  "Q:options": {
    "dynamicEnum": {
      "type": "toolEndpoint",
      "withData": true,
      "endpoint": "dynamic-enum/highlightDataSeries"
    }
  }
}
```

## availabilityChecks
`availabilityChecks` is an array consisting of objects of check configs. Only the type `toolEndpoint` is implemented now, but this can be used to have some role based checks as well. config looks like this:
```
"isColumnChart": {
  "title": "Balken statt Säulen",
  "type": "boolean",
  "Q:options": {
    "availabilityChecks": [
      {
        "type": "toolEndpoint",
        "withData": true,
        "endpoint": "option-availability/isColumnChart"
      }
    ]
  }
}
```
the endpoint has to return json like `{"available": true}` or `{"available": false}`