### PR TITLE
Feat token auth

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -10,6 +10,7 @@ System.config({
     "ajv": "npm:ajv@4.11.8",
     "array2d": "npm:array2d@0.0.5",
     "aurelia-animator-css": "npm:aurelia-animator-css@1.0.2",
+    "aurelia-authentication": "npm:aurelia-authentication@3.6.0",
     "aurelia-binding": "npm:aurelia-binding@1.2.1",
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.1",
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
@@ -97,6 +98,27 @@ System.config({
       "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
       "aurelia-pal": "npm:aurelia-pal@1.3.0",
       "aurelia-templating": "npm:aurelia-templating@1.4.2"
+    },
+    "npm:aurelia-api@3.1.1": {
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
+      "aurelia-fetch-client": "npm:aurelia-fetch-client@1.1.2",
+      "aurelia-framework": "npm:aurelia-framework@1.1.2",
+      "aurelia-path": "npm:aurelia-path@1.1.1",
+      "extend": "npm:extend@3.0.1"
+    },
+    "npm:aurelia-authentication@3.6.0": {
+      "aurelia-api": "npm:aurelia-api@3.1.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.3.1",
+      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.1",
+      "aurelia-fetch-client": "npm:aurelia-fetch-client@1.1.2",
+      "aurelia-logging": "npm:aurelia-logging@1.3.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.3",
+      "aurelia-pal": "npm:aurelia-pal@1.3.0",
+      "aurelia-path": "npm:aurelia-path@1.1.1",
+      "aurelia-router": "npm:aurelia-router@1.3.0",
+      "aurelia-templating-resources": "npm:aurelia-templating-resources@1.4.0",
+      "extend": "npm:extend@3.0.1",
+      "jwt-decode": "npm:jwt-decode@2.2.0"
     },
     "npm:aurelia-binding@1.2.1": {
       "aurelia-logging": "npm:aurelia-logging@1.3.1",
@@ -273,6 +295,10 @@ System.config({
     },
     "npm:json-stable-stringify@1.0.1": {
       "jsonify": "npm:jsonify@0.0.0"
+    },
+    "npm:jwt-decode@2.2.0": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:leaflet-geocoder-mapzen@1.8.0": {
       "leaflet": "npm:leaflet@1.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
       "ajv": "npm:ajv@^4.11.5",
       "array2d": "npm:array2d@^0.0.5",
       "aurelia-animator-css": "npm:aurelia-animator-css@^1.0.0",
+      "aurelia-authentication": "npm:aurelia-authentication@^3.6.0",
       "aurelia-binding": "npm:aurelia-binding@^1.1.1",
       "aurelia-bootstrapper": "npm:aurelia-bootstrapper@^1.0.0",
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.3.0",

--- a/client/src/dialogs/account-dialog.html
+++ b/client/src/dialogs/account-dialog.html
@@ -16,6 +16,9 @@
         <label for="acronym">Kürzel
           <input type="text" id="acronym" value.bind="user.data.acronym">
         </label>
+        <label for="initials">Initialen
+          <input type="text" id="initials" value.bind="user.data.initials">
+        </label>
         <button-primary
           click.delegate="saveUser()"
           icon="proceed"><span t="general.saveChanges"></span></button-primary>

--- a/client/src/dialogs/account-dialog.html
+++ b/client/src/dialogs/account-dialog.html
@@ -10,6 +10,7 @@
         <label for="department">Ressort</label>
         <div class="q-select">
           <select value.bind="user.data.department">
+            <option value="default"></option>
             <option repeat.for="department of departments" value.bind="department">${department}</option>
           </select>
         </div>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -109,6 +109,7 @@ export async function configure(aurelia) {
         baseConfig.configure({
           baseUrl: QServerBaseUrl,
           loginUrl: '/authenticate',
+          loginRedirect: false,
           logoutRedirect: false
         });
       });

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,7 +1,7 @@
 // clear the load error timeout
 window.clearTimeout(window.QLoadErrorTimeout);
 
-import { LogManager } from 'aurelia-framework';
+import { LogManager, Loader } from 'aurelia-framework';
 import { ConsoleAppender } from 'aurelia-logging-console';
 
 import QConfig from 'resources/QConfig.js';
@@ -33,6 +33,8 @@ export async function configure(aurelia) {
   aurelia.use.singleton(SchemaEditorInputAvailabilityChecker);
   aurelia.use.singleton(User);
 
+  const QServerBaseUrl = await qEnv.QServerBaseUrl;
+
   aurelia.use
     .standardConfiguration()
     .feature('elements/atoms')
@@ -57,7 +59,6 @@ export async function configure(aurelia) {
       }
 
       // we need these for the calculation of the path to the locales files
-      const QServerBaseUrl = await qEnv.QServerBaseUrl;
       const configuredTools = await aurelia.container.get(ToolsInfo).getAvailableTools();
       const toolNames = configuredTools.map(tool => tool.name);
 
@@ -90,8 +91,28 @@ export async function configure(aurelia) {
         load: 'languageOnly',
         debug: false
       });
-    })
-  ;
+    });
+
+  // if we have token based auth configured, load and configure aurelia-authentication plugin
+  const qConfig = aurelia.container.get(QConfig);
+  const authConfig = await qConfig.get('auth');
+  if (authConfig && authConfig.type === 'token') {
+    // configure the aurelia-fetch-client interceptor to add the auth token to every request
+    const loader = aurelia.container.get(Loader);
+    const AureliaAuthentication = await loader.loadModule('aurelia-authentication');
+    const FetchConfig = AureliaAuthentication.FetchConfig;
+    const fetchConfig = aurelia.container.get(FetchConfig);
+    fetchConfig.configure();
+
+    aurelia.use
+      .plugin('aurelia-authentication', baseConfig => {
+        baseConfig.configure({
+          baseUrl: QServerBaseUrl,
+          loginUrl: '/authenticate',
+          logoutRedirect: false
+        });
+      });
+  }
 
   const devLogging = await qEnv.devLogging;
   let logLevel = LogManager.logLevel.info;

--- a/client/src/resources/Item.js
+++ b/client/src/resources/Item.js
@@ -8,8 +8,9 @@ export default class Item {
 
   isSaved = true;
 
-  constructor(user) {
+  constructor(user, httpClient) {
     this.user = user;
+    this.httpClient = httpClient;
   }
 
   get id() {
@@ -37,7 +38,7 @@ export default class Item {
   async load(id) {
     const QServerBaseUrl = await qEnv.QServerBaseUrl;
 
-    const response = await fetch(`${QServerBaseUrl}/item/${id}`);
+    const response = await this.httpClient.fetch(`${QServerBaseUrl}/item/${id}`);
 
     if (!response.ok) {
       throw response;
@@ -85,7 +86,7 @@ export default class Item {
     }
 
     const QServerBaseUrl = await qEnv.QServerBaseUrl;
-    const response = await fetch(`${QServerBaseUrl}/item`, {
+    const response = await this.httpClient.fetch(`${QServerBaseUrl}/item`, {
       method: method,
       credentials: 'include',
       body: JSON.stringify(this.conf)

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -1,19 +1,21 @@
 import { inject } from 'aurelia-framework';
 import { BindingEngine } from 'aurelia-binding';
+import { HttpClient } from 'aurelia-fetch-client';
 import qEnv from 'resources/qEnv.js';
 import User from 'resources/User.js';
 import Item from 'resources/Item.js';
 import ToolsInfo from 'resources/ToolsInfo.js';
 
-@inject(User, ToolsInfo, BindingEngine)
+@inject(User, ToolsInfo, BindingEngine, HttpClient)
 export default class ItemStore {
 
   items = {};
 
-  constructor(user, toolsInfo, bindingEngine) {
+  constructor(user, toolsInfo, bindingEngine, httpClient) {
     this.user = user;
     this.toolsInfo = toolsInfo;
     this.bindingEngine = bindingEngine;
+    this.httpClient = httpClient;
 
     this.initFilters();
   }
@@ -85,7 +87,7 @@ export default class ItemStore {
   }
 
   getNewItem() {
-    let item = new Item(this.user);
+    let item = new Item(this.user, this.httpClient);
     item.setDepartmentToUserDepartment();
     this.bindingEngine
       .propertyObserver(item, 'isSaved')
@@ -165,7 +167,7 @@ export default class ItemStore {
 
   async loadItems(searchRequestBody) {
     const QServerBaseUrl = await qEnv.QServerBaseUrl;
-    const response = await fetch(`${QServerBaseUrl}/search`, {
+    const response = await this.httpClient.fetch(`${QServerBaseUrl}/search`, {
       method: 'POST',
       body: JSON.stringify(searchRequestBody)
     });
@@ -181,7 +183,7 @@ export default class ItemStore {
 
     const items = data.rows
       .map(row => {
-        let item = new Item(this.user);
+        let item = new Item(this.user, this.httpClient);
         item.addConf(row.doc);
         this.items[row.doc._id];
         return item;

--- a/client/src/resources/User.js
+++ b/client/src/resources/User.js
@@ -1,8 +1,12 @@
+import { inject } from 'aurelia-framework';
+import { HttpClient } from 'aurelia-fetch-client';
 import qEnv from 'resources/qEnv.js';
 
+@inject(HttpClient)
 export default class User {
 
-  constructor() {
+  constructor(httpClient) {
+    this.httpClient = httpClient;
     this.isLoggedIn = false;
     this.loaded = this.load();
   }
@@ -10,7 +14,7 @@ export default class User {
   async load() {
     try {
       const QServerBaseUrl = await qEnv.QServerBaseUrl;
-      const response = await fetch(`${QServerBaseUrl}/user`, {
+      const response = await this.httpClient.fetch(`${QServerBaseUrl}/user`, {
         credentials: 'include'
       });
 

--- a/client/src/resources/User.js
+++ b/client/src/resources/User.js
@@ -37,6 +37,9 @@ export default class User {
   }
 
   setUserConfig(key, value) {
+    if (!this.data.hasOwnProperty('config')) {
+      this.data.config = {};
+    }
     this.data.config[key] = value;
     this.save();
   }
@@ -58,7 +61,7 @@ export default class User {
   async save() {
     try {
       const QServerBaseUrl = await qEnv.QServerBaseUrl;
-      const response = await fetch(`${QServerBaseUrl}/user`, {
+      const response = await this.httpClient.fetch(`${QServerBaseUrl}/user`, {
         credentials: 'include',
         method: 'PUT',
         body: JSON.stringify(this.data)


### PR DESCRIPTION
If `editorConfig.authConfig.type === 'token'` (coming from Q-server) then we use aurelia-authentication to handle a token coming from `/authenticate`. aurelia-authentication adds an interceptor to aurelia-fetch-client, so the token is added to all the requests that use aurelia-fetch-client.

this is all only loaded if the authConfig.type is set to `token`. Otherwise the current functionality stays untouched.

This implements #3