### PR TITLE
fix: ensure data is an array in schema-editor-array

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-array.html
+++ b/client/src/elements/schema-editor/schema-editor-array.html
@@ -14,9 +14,9 @@
         <span class="q-text" if.bind="!options.expandable.itemLabelProperty || !entryLabels[$index]">${$index + 1}</span>
 
         <div class="schema-editor-array__entry-actions">
-          <button-tertiary if.bind="!$first" icon="up" click.delegate="moveElementUp(data, $index)" size="small"></button-tertiary>
-          <button-tertiary if.bind="!$last" icon="down" click.delegate="moveElementDown(data, $index)" size="small"></button-tertiary>
-          <delete-button action.call="deleteElement(data, $index)" size="small" button-type="tertiary"></delete-button>
+          <button-tertiary if.bind="!$first" icon="up" click.delegate="moveElementUp($index)" size="small"></button-tertiary>
+          <button-tertiary if.bind="!$last" icon="down" click.delegate="moveElementDown($index)" size="small"></button-tertiary>
+          <delete-button action.call="deleteElement($index)" size="small" button-type="tertiary"></delete-button>
         </div>
       </div>
       <schema-editor-wrapper
@@ -27,15 +27,15 @@
           no-object-title="true">
       </schema-editor-wrapper>
       <div class="schema-editor-array__entry-actions" if.bind="!options.expandable">
-        <button-tertiary if.bind="!$first" icon="up" click.delegate="moveElementUp(data, $index)" size="small"></button-tertiary>
-        <button-tertiary if.bind="!$last" icon="down" click.delegate="moveElementDown(data, $index)" size="small"></button-tertiary>
-        <delete-button action.call="deleteElement(data, $index)" size="small" button-type="tertiary"></delete-button>
+        <button-tertiary if.bind="!$first" icon="up" click.delegate="moveElementUp($index)" size="small"></button-tertiary>
+        <button-tertiary if.bind="!$last" icon="down" click.delegate="moveElementDown($index)" size="small"></button-tertiary>
+        <delete-button action.call="deleteElement($index)" size="small" button-type="tertiary"></delete-button>
       </div>
   </div>
 
   <button-secondary class="schema-editor-array__add-item-button"
     repeat.for="arrayEntryOption of arrayEntryOptions"
-    click.delegate="addElement(data, arrayEntryOption.schema)">
+    click.delegate="addElement(arrayEntryOption.schema)">
       <span t="editor.arrayEntryAdd" t-params.bind="arrayEntryOption"></span>
   </button-secondary>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -57,37 +57,37 @@ export class SchemaEditorArray {
     }
   }
 
-  addElement(data, schema) {
-    let entry = this.objectFromSchemaGenerator.generateFromSchema(schema);
-    if (data === undefined) {
-      data = [];
+  addElement(schema) {
+    if (this.data === undefined) {
+      this.data = [];
     }
-    data.push(entry);
-    this.expand(data.indexOf(entry));
+    const entry = this.objectFromSchemaGenerator.generateFromSchema(schema);
+    this.data.push(entry);
+    this.expand(this.data.indexOf(entry));
     this.calculateEntryLabels();
     if (this.change) {
       this.change();
     }
   }
 
-  moveElementUp(data, index) {
-    data.splice(index - 1, 0, data.splice(index, 1)[0]);
+  moveElementUp(index) {
+    this.data.splice(index - 1, 0, this.data.splice(index, 1)[0]);
     this.calculateEntryLabels();
     if (this.change) {
       this.change();
     }
   }
 
-  moveElementDown(data, index) {
-    data.splice(index + 1, 0, data.splice(index, 1)[0]);
+  moveElementDown(index) {
+    this.data.splice(index + 1, 0, this.data.splice(index, 1)[0]);
     this.calculateEntryLabels();
     if (this.change) {
       this.change();
     }
   }
 
-  deleteElement(data, index) {
-    data.splice(index, 1);
+  deleteElement(index) {
+    this.data.splice(index, 1);
     this.calculateEntryLabels();
     if (this.change) {
       this.change();


### PR DESCRIPTION
This would fix the issue with the handling of existing items of a tool that got a new property of type array.

We have 3 options to solve the issue (probably more that did not came to my mind):
1. force the tool implementor to run a migration in these cases
2. somehow apply any new defaults to existing items when opening them in editor
3. make sure that we have an array in schema-editor-array if the data value is `undefined`

This PR implements 3.

Not sure if this is really the best solution.
I like it because it makes extending options on tools easier (because one does not have to write and run a migration). It works the same for `string` and other primitive types (where we do not fail if we have `undefined`). It is not destructive as it only overwrites the property if it is `undefined`.

We could implement the same for objects as well, as they would probably fail in a similar way.