### PR TITLE
feat: add publication filter to be configured by Q-server editor config.

### DIFF
--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -55,6 +55,7 @@
     "byMe": "von mir",
     "allDepartments": "alle Ressorts",
     "myDepartment": "nur mein Ressort",
+    "allPublications": "alle Publikationen",
     "allStates": "alle Zustände",
     "onlyActive": "nur aktive",
     "onlyInactive": "nur inaktive"

--- a/client/locales/en/translation.json
+++ b/client/locales/en/translation.json
@@ -56,6 +56,7 @@
     "byMe": "by me",
     "allDepartments": "all departments",
     "myDepartment": "my department only",
+    "allPublications": "all publications",
     "allStates": "all states",
     "onlyActive": "active only",
     "onlyInactive": "inactive only"

--- a/client/src/dialogs/account-dialog.html
+++ b/client/src/dialogs/account-dialog.html
@@ -7,6 +7,13 @@
         Username: ${user.data.username}<br>
       </p>
       <form class="q-form" ref="userForm">
+        <label for="publication" if.bind="publications.length > 0">Publikation</label>
+        <div class="q-select" if.bind="publications.length > 0">
+          <select value.bind="user.data.publication">
+            <option value="default"></option>
+            <option repeat.for="publication of publications" value.bind="publication.key">${publication.label}</option>
+          </select>
+        </div>
         <label for="department">Ressort</label>
         <div class="q-select">
           <select value.bind="user.data.department">

--- a/client/src/dialogs/account-dialog.js
+++ b/client/src/dialogs/account-dialog.js
@@ -21,12 +21,13 @@ export class AccountDialog {
     this.auth = auth;
     this.qConfig = qConfig;
 
-    this.loadDepartments();
+    this.loadData();
   }
 
-  async loadDepartments() {
+  async loadData() {
     let departments = await this.qConfig.get('departments');
     this.departments = departments.sort();
+    this.publications = await this.qConfig.get('publications');
   }
 
   async activate(config) {

--- a/client/src/elements/item-preview/item-preview.html
+++ b/client/src/elements/item-preview/item-preview.html
@@ -3,7 +3,7 @@
   <require from="./item-preview.css"></require>
   <require from="../molecules/radio-button-group"></require>
 
-  <form class="item-preview__settings">
+  <form class="item-preview__settings" if.bind="initialised">
     <div class="q-form">
       <label class="q-text-small q-text--light"><span t="general.previewTargetLabel"></span>
         <select value.bind="targetProxy.target">

--- a/client/src/elements/item-preview/item-preview.html
+++ b/client/src/elements/item-preview/item-preview.html
@@ -7,7 +7,7 @@
     <div class="q-form">
       <label class="q-text-small q-text--light"><span t="general.previewTargetLabel"></span>
         <select value.bind="targetProxy.target">
-          <option repeat.for="target of availableTargets" model.bind="target">${target.label}</option>
+          <option repeat.for="publication of publications" model.bind="getTargetForKey(publication.previewTarget)">${publication.label}</option>
         </select>
       </label>
     </div>

--- a/client/src/elements/organisms/meta-editor.html
+++ b/client/src/elements/organisms/meta-editor.html
@@ -1,11 +1,19 @@
 <template>
   <form class="q-form">
-    <label class="q-text-small q-text--light">Ressort
-      <select value.bind="data.department">
+    <label for="publication" if.bind="publications.length > 0">Publikation</label>
+    <div class="q-select" if.bind="publications.length > 0">
+      <select name="publication" value.bind="data.publication">
+        <option value="default"></option>
+        <option repeat.for="publication of publications" value.bind="publication.key">${publication.label}</option>
+      </select>
+    </div>
+    <label for="department">Ressort</label>
+    <div class="q-select">
+      <select name="department" value.bind="data.department">
         <option value="default"></option>
         <option repeat.for="department of departments" value.bind="department">${department}</option>
       </select>
-    </label>
+    </div>
     <label class="q-text-small q-text--light">Annotationen
       <textarea value.bind="data.annotations" style="height: 150px;"></textarea>
     </label>

--- a/client/src/elements/organisms/meta-editor.js
+++ b/client/src/elements/organisms/meta-editor.js
@@ -6,10 +6,15 @@ export class MetaEditor {
 
   @bindable data
 
-  constructor(qConfig) {
+  constructor(qConfig, qTargets) {
     qConfig.get('departments')
       .then(departments => {
         this.departments = departments.sort();
+      });
+
+    qConfig.get('publications')
+      .then(publications => {
+        this.publications = publications;
       });
   }
 

--- a/client/src/resources/Item.js
+++ b/client/src/resources/Item.js
@@ -35,6 +35,13 @@ export default class Item {
     this.conf.department = this.user.data.department;
   }
 
+  async setPublicationToUserPublication() {
+    await this.user.loaded;
+    if (this.user.data.publication) {
+      this.conf.publication = this.user.data.publication;
+    }
+  }
+
   async load(id) {
     const QServerBaseUrl = await qEnv.QServerBaseUrl;
 

--- a/client/src/resources/Item.js
+++ b/client/src/resources/Item.js
@@ -60,6 +60,7 @@ export default class Item {
     this.conf._rev = undefined;
     this.conf.active = false;
     await this.setDepartmentToUserDepartment();
+    await this.setPublicationToUserPublication();
     return this.save();
   }
 


### PR DESCRIPTION
This needs an additional property in Q-server editor config like this:

```
publications: [
  {
    key: 'nzz',
    label: 'NZZ',
    previewTarget: 'nzz_ch'
  }
]
```
where the target is the key of a target configured in target config.

The user can set her publication in account-dialog. If it is defined, the user will see the target configured for her publication in the preview.

There is no direct connection between publication and target as there can be multiple targets per publication (website, app, amp etc..)