### PR TITLE
feat(schema-editor): add new schema-editor-html 

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -6,6 +6,7 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
+
   map: {
     "ajv": "npm:ajv@5.3.0",
     "array2d": "npm:array2d@0.0.5",

--- a/client/config.js
+++ b/client/config.js
@@ -41,11 +41,13 @@ System.config({
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.7",
     "css": "github:systemjs/plugin-css@0.1.36",
+    "debounce": "npm:debounce@1.1.0",
     "handsontable": "npm:handsontable@0.32.0",
     "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",
     "i18next-fetch-backend": "npm:i18next-fetch-backend@0.0.1",
     "leaflet": "npm:leaflet@1.2.0",
     "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
+    "quill": "npm:quill@1.3.4",
     "text": "github:systemjs/plugin-text@0.0.8",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.4.1"
@@ -277,7 +279,11 @@ System.config({
     },
     "npm:buffer@5.0.8": {
       "base64-js": "npm:base64-js@1.2.1",
-      "ieee754": "npm:ieee754@1.1.8"
+      "ieee754": "npm:ieee754@1.1.8",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
+    },
+    "npm:clone@2.1.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1"
     },
     "npm:core-js@1.2.7": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
@@ -287,6 +293,9 @@ System.config({
     },
     "npm:fast-deep-equal@1.0.0": {
       "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:fast-diff@1.1.2": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:fast-json-stable-stringify@2.0.0": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
@@ -338,6 +347,21 @@ System.config({
     },
     "npm:punycode@1.3.2": {
       "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:quill-delta@3.6.2": {
+      "deep-equal": "npm:deep-equal@1.0.1",
+      "extend": "npm:extend@3.0.1",
+      "fast-diff": "npm:fast-diff@1.1.2"
+    },
+    "npm:quill@1.3.4": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
+      "clone": "npm:clone@2.1.1",
+      "deep-equal": "npm:deep-equal@1.0.1",
+      "eventemitter3": "npm:eventemitter3@2.0.3",
+      "extend": "npm:extend@3.0.1",
+      "parchment": "npm:parchment@1.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "quill-delta": "npm:quill-delta@3.6.2"
     },
     "npm:url@0.10.3": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -57,16 +57,6 @@
       "integrity": "sha512-tHdDdGUBKTbiLLwf5mF78EP35F31UZekG+GRNowl8G5rMQoupAT4qWn/7AaGOvmaqvROdqC3Io/hP1ZyO58QkA==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1642,8 +1632,8 @@
       "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -3836,6 +3826,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3844,14 +3842,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5577,6 +5567,16 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jspm": {
       "version": "0.16.53",
@@ -8540,6 +8540,12 @@
         "limiter": "1.1.2"
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8550,12 +8556,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/client/package.json
+++ b/client/package.json
@@ -70,11 +70,13 @@
       "aurelia-templating-router": "npm:aurelia-templating-router@^1.1.0",
       "aurelia-testing": "npm:aurelia-testing@^1.0.0-beta.2.0.1",
       "css": "github:systemjs/plugin-css@^0.1.32",
+      "debounce": "npm:debounce@^1.1.0",
       "handsontable": "npm:handsontable@^0.32.0-beta1",
       "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",
       "i18next-fetch-backend": "npm:i18next-fetch-backend@^0.0.1",
       "leaflet": "npm:leaflet@1.2.0",
       "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
+      "quill": "npm:quill@^1.3.4",
       "text": "github:systemjs/plugin-text@^0.0.8"
     },
     "devDependencies": {}

--- a/client/src/elements/schema-editor/schema-editor-html.css
+++ b/client/src/elements/schema-editor/schema-editor-html.css
@@ -1,3 +1,7 @@
 schema-editor-html .ql-container {
   font-family: var(--q-font-family-content);
 }
+
+schema-editor-html .ql-editor {
+  background-color: var(--q-color-white);
+}

--- a/client/src/elements/schema-editor/schema-editor-html.css
+++ b/client/src/elements/schema-editor/schema-editor-html.css
@@ -1,0 +1,3 @@
+schema-editor-html .ql-container {
+  font-family: var(--q-font-family-content);
+}

--- a/client/src/elements/schema-editor/schema-editor-html.html
+++ b/client/src/elements/schema-editor/schema-editor-html.html
@@ -1,0 +1,9 @@
+<template>
+  <require from="./schema-editor-html.css"></require>
+  <label>
+    ${schema["title"]}
+  </label>
+  <div class="schema-editor-input">
+    <div ref="contentElement"></div>
+  </div>
+</template>

--- a/client/src/elements/schema-editor/schema-editor-html.js
+++ b/client/src/elements/schema-editor/schema-editor-html.js
@@ -1,0 +1,80 @@
+import { bindable, inject, Loader, LogManager } from 'aurelia-framework';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+import { Notification } from 'aurelia-notification';
+import debounce from 'debounce';
+
+const allowedTagsFormatOptionsMapping = {
+  a: 'link'
+};
+
+const log = LogManager.getLogger('Q');
+
+@checkAvailability()
+@inject(Element, Notification, Loader)
+export class SchemaEditorHtml {
+
+  @bindable schema;
+  @bindable data;
+  @bindable change;
+  @bindable required;
+
+  constructor(element, notification, loader) {
+    this.element = element;
+    this.notification = notification;
+    this.loader = loader;
+  }
+
+  async attached() {
+    this.contentElement.innerHTML = this.data;
+
+    const Quill = await this.loader.loadModule('quill');
+    await this.loader.loadModule('npm:quill@1.3.4/dist/quill.core.css!');
+    await this.loader.loadModule('npm:quill@1.3.4/dist/quill.snow.css!');
+    this.quill = new Quill(this.contentElement, {
+      modules: {
+        toolbar: this.getToolbarControls()
+      },
+      formats: this.getAllowedFormats(),
+      theme: 'snow',
+      bounds: this.element
+    });
+
+    this.quill.on('text-change', debounce((delta, oldDelta, source) => {
+      this.data = this.quill.root.innerHTML;
+      this.change();
+    }, 800));
+  }
+
+  getToolbarControls() {
+    const toolbarControls = [];
+    try {
+      if (this.schema['Q:options'].type.allowedTags) {
+        for (let tag of this.schema['Q:options'].type.allowedTags) {
+          if (allowedTagsFormatOptionsMapping.hasOwnProperty(tag)) {
+            toolbarControls.push(allowedTagsFormatOptionsMapping[tag]);
+          }
+        }
+      }
+    } catch (err) {
+      log.error(err);
+    }
+    return toolbarControls;
+  }
+
+  getAllowedFormats() {
+    const formats = [];
+    try {
+      if (this.schema['Q:options'].type.allowedTags) {
+        for (let tag of this.schema['Q:options'].type.allowedTags) {
+          if (allowedTagsFormatOptionsMapping.hasOwnProperty(tag)) {
+            formats.push(allowedTagsFormatOptionsMapping[tag]);
+          }
+        }
+      }
+    } catch (err) {
+      log.error(err);
+    }
+    return formats;
+  }
+
+}

--- a/client/src/elements/schema-editor/schema-editor-html.js
+++ b/client/src/elements/schema-editor/schema-editor-html.js
@@ -25,13 +25,15 @@ export class SchemaEditorHtml {
   }
 
   async attached() {
-    this.contentElement.innerHTML = this.data;
+    if (typeof this.data === 'string') {
+      this.contentElement.innerHTML = this.data;
+    }
 
     const Quill = await this.loader.loadModule('quill');
     await this.loader.loadModule('npm:quill@1.3.4/dist/quill.core.css!');
     await this.loader.loadModule('npm:quill@1.3.4/dist/quill.snow.css!');
 
-    var Link = Quill.import('formats/link');
+    const Link = Quill.import('formats/link');
 
     // extend Quill Link class to set noopener noreferrer rel on the link with target blank
     // because: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

--- a/client/src/elements/schema-editor/schema-editor-html.js
+++ b/client/src/elements/schema-editor/schema-editor-html.js
@@ -30,6 +30,24 @@ export class SchemaEditorHtml {
     const Quill = await this.loader.loadModule('quill');
     await this.loader.loadModule('npm:quill@1.3.4/dist/quill.core.css!');
     await this.loader.loadModule('npm:quill@1.3.4/dist/quill.snow.css!');
+
+    var Link = Quill.import('formats/link');
+
+    // extend Quill Link class to set noopener noreferrer rel on the link with target blank
+    // because: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/
+    class QLink extends Link {
+      static create(value) {
+        let node = super.create(value);
+        value = this.sanitize(value);
+        node.setAttribute('href', value);
+        node.setAttribute('target', '_blank');
+        node.setAttribute('rel', 'noopener noreferrer');
+        return node;
+      }
+    }
+
+    Quill.register(QLink);
+
     this.quill = new Quill(this.contentElement, {
       modules: {
         toolbar: this.getToolbarControls()

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -17,6 +17,15 @@
       required.bind="required"></schema-editor-string>
   </div>
 
+  <div if.bind="getType(schema) === 'html'" class="schema-editor-block">
+    <require from="./schema-editor-html"></require>
+    <schema-editor-html
+      schema.bind="schema"
+      data.two-way="data"
+      change.bind="change"
+      required.bind="required"></schema-editor-html>
+  </div>
+
   <div if.bind="getType(schema) === 'textarea'" class="schema-editor-block">
     <require from="./schema-editor-textarea"></require>
     <schema-editor-textarea

--- a/client/src/styles/config.css
+++ b/client/src/styles/config.css
@@ -38,6 +38,9 @@
   --q-color-error-light: #f3d1cd;
 
   /* fonts */
+  --q-font-family-ui: 'Inconsolata', monospace;
+  --q-font-family-content: Roboto, sans-serif;
+
   --q-h1-size: 22px;
   --q-h2-size: 20px;
   --q-h3-size: 18px;

--- a/client/src/styles/fonts.css
+++ b/client/src/styles/fonts.css
@@ -1,5 +1,5 @@
 body {
-  font-family: 'Inconsolata', monospace;
+  font-family: var(--q-font-family-ui);
   line-height: 1.2;
   color: var(--q-text-color);
 }


### PR DESCRIPTION
- triggered from schema with `"Q:type": "html"
- uses https://quilljs.com/
- currently supports only `a` tags in html, can be extended if a tool needs it
- supported tags need to be configured, otherwise nothing will be allowed, so it's a whitelist approach
