### PR TITLE
(schema-editor) add schema-editor-files to upload one or many files

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -41,6 +41,7 @@ System.config({
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.7",
     "css": "github:systemjs/plugin-css@0.1.36",
+    "dropzone": "npm:dropzone@5.2.0",
     "handsontable": "npm:handsontable@0.32.0",
     "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",
     "i18next-fetch-backend": "npm:i18next-fetch-backend@0.0.1",
@@ -277,13 +278,17 @@ System.config({
     },
     "npm:buffer@5.0.8": {
       "base64-js": "npm:base64-js@1.2.1",
-      "ieee754": "npm:ieee754@1.1.8"
+      "ieee754": "npm:ieee754@1.1.8",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:core-js@1.2.7": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
+    },
+    "npm:dropzone@5.2.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:fast-deep-equal@1.0.0": {
       "assert": "github:jspm/nodelibs-assert@0.1.0"

--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -82,7 +82,7 @@
     "maxNumberOfFilesExceed": "Es können keine weiteren Dateien hochgeladen werden"
   },
   "dropzone": {
-    "dictDefaultMessage": "Legen Sie Dateien hier ab um Sie hochzuladen",
+    "dictDefaultMessage": "Anklicken oder Bilder hierhin ziehen, um sie hochzuladen",
     "dictFallbackMessage": "Ihr Browser unterstützt Drag&Drop Dateiuploads nicht",
     "dictFallbackText": "Benutzen Sie das Formular um Ihre Dateien hochzuladen",
     "dictFileTooBig": "Die Datei ist zu groß. Die maximale Dateigröße beträgt {{maxFileSize}}MB",

--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -78,6 +78,18 @@
     "graphicNeedsATitle": "Grafik braucht einen Titel",
     "failedLoadingItems": "Grafiken konnten nicht geladen werden",
     "failedToLoadItem": "Die Grafik konnte nicht geladen werden.",
-    "toolNotAvailable": "Dieses Tool steht nicht zur Verfügung"
+    "toolNotAvailable": "Dieses Tool steht nicht zur Verfügung",
+    "maxNumberOfFilesExceed": "Es können keine weiteren Dateien hochgeladen werden"
+  },
+  "dropzone": {
+    "dictDefaultMessage": "Legen Sie Dateien hier ab um Sie hochzuladen",
+    "dictFallbackMessage": "Ihr Browser unterstützt Drag&Drop Dateiuploads nicht",
+    "dictFallbackText": "Benutzen Sie das Formular um Ihre Dateien hochzuladen",
+    "dictFileTooBig": "Die Datei ist zu groß. Die maximale Dateigröße beträgt {{maxFileSize}}MB",
+    "dictInvalidFileType": "Eine Datei dieses Typs kann nicht hochgeladen werden",
+    "dictResponseError": "Der Server hat ihre Anfrage mit Status {{statusCode}} abgelehnt",
+    "dictCancelUpload": "Hochladen abbrechen",
+    "dictRemoveFile": "Datei entfernen",
+    "dictMaxFilesExceeded": "Sie können keine weiteren Dateien mehr hochladen"
   }
 }

--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -85,7 +85,7 @@
     "dictDefaultMessage": "Anklicken oder Bilder hierhin ziehen, um sie hochzuladen",
     "dictFallbackMessage": "Ihr Browser unterstützt Drag&Drop Dateiuploads nicht",
     "dictFallbackText": "Benutzen Sie das Formular um Ihre Dateien hochzuladen",
-    "dictFileTooBig": "Die Datei ist zu groß. Die maximale Dateigröße beträgt {{maxFileSize}}MB",
+    "dictFileTooBig": "Die Datei ist zu gross. Die maximale Dateigrösse beträgt {{maxFileSize}}MB",
     "dictInvalidFileType": "Eine Datei dieses Typs kann nicht hochgeladen werden",
     "dictResponseError": "Der Server hat ihre Anfrage mit Status {{statusCode}} abgelehnt",
     "dictCancelUpload": "Hochladen abbrechen",

--- a/client/locales/en/translation.json
+++ b/client/locales/en/translation.json
@@ -79,6 +79,19 @@
     "graphicNeedsATitle": "Graphic needs a title",
     "failedLoadingItems": "Failed loading graphics",
     "failedToLoadItem": "Failed to load the graphic.",
-    "toolNotAvailable": "This tool is not available"
+    "toolNotAvailable": "This tool is not available",
+    "maxNumberOfFilesExceed": "You are not allowed to upload more files"
+  },
+  "dropzone": {
+    "dictDefaultMessage": "Drop files here to upload",
+    "dictFallbackMessage": "Your browser does not support drag'n'drop file uploads.",
+    "dictFallbackText": "Please use the fallback form below to upload your files like in the olden days.",
+    "dictFileTooBig": "File is too big ({{filesize}}MiB). Max filesize: {{maxFilesize}}MiB.",
+    "dictInvalidFileType": "You can't upload files of this type.",
+    "dictResponseError": "Server responded with {{statusCode}} code.",
+    "dictCancelUpload": "Cancel upload",
+    "dictCancelUploadConfirmation": "Are you sure you want to cancel this upload?",
+    "dictRemoveFile": "Remove file",
+    "dictMaxFilesExceeded": "You can not upload any more files."
   }
 }

--- a/client/locales/en/translation.json
+++ b/client/locales/en/translation.json
@@ -92,6 +92,6 @@
     "dictCancelUpload": "Cancel upload",
     "dictCancelUploadConfirmation": "Are you sure you want to cancel this upload?",
     "dictRemoveFile": "Remove file",
-    "dictMaxFilesExceeded": "You can not upload any more files."
+    "dictMaxFilesExceeded": "You cannot upload any more files."
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -70,6 +70,7 @@
       "aurelia-templating-router": "npm:aurelia-templating-router@^1.1.0",
       "aurelia-testing": "npm:aurelia-testing@^1.0.0-beta.2.0.1",
       "css": "github:systemjs/plugin-css@^0.1.32",
+      "dropzone": "npm:dropzone@^5.2.0",
       "handsontable": "npm:handsontable@^0.32.0-beta1",
       "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",
       "i18next-fetch-backend": "npm:i18next-fetch-backend@^0.0.1",

--- a/client/src/elements/schema-editor/schema-editor-files.css
+++ b/client/src/elements/schema-editor/schema-editor-files.css
@@ -1,0 +1,21 @@
+schema-editor-files .dropzone {
+  padding: calc(var(--q-space-base) / 2);
+  font-size: var(--q-text-small-size);
+  line-height: 1.33;
+  color: var(--q-text-light-color);
+  border: 1px dashed var(--q-color-gray-4);
+  background-color: var(--q-color-white);
+}
+
+schema-editor-files .dropzone .dz-preview {
+  margin: calc(var(--q-space-base) / 2);
+}
+
+schema-editor-files .dropzone .dz-preview .dz-image {
+  border-radius: 0;
+}
+
+schema-editor-files .dropzone .dz-preview .dz-remove {
+  font-size: var(--q-text-small-size);
+}
+

--- a/client/src/elements/schema-editor/schema-editor-files.html
+++ b/client/src/elements/schema-editor/schema-editor-files.html
@@ -1,0 +1,6 @@
+<template class="schema-editor-input">
+  <require from="./schema-editor-files.css"></require>
+  <div >
+    <div class="dropzone" ref="dropzoneElement"></div>
+  </div>
+</template>

--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -1,0 +1,140 @@
+import { bindable, inject, Loader, LogManager } from 'aurelia-framework';
+import { Notification } from 'aurelia-notification';
+import { I18N } from 'aurelia-i18n';
+import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+import qEnv from 'resources/qEnv.js';
+import { AuthService } from 'aurelia-authentication';
+const log = LogManager.getLogger('Q');
+
+@checkAvailability()
+@inject(Loader, AuthService, Notification, I18N)
+export class SchemaEditorFiles {
+
+  @bindable schema;
+  @bindable data;
+  @bindable change;
+  @bindable required;
+
+  options = {
+    maxFiles: null
+  }
+
+  constructor(loader, authService, notification, i18n) {
+    this.loader = loader;
+    this.authService = authService;
+    this.notification = notification;
+    this.i18n = i18n;
+  }
+
+  schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (!this.schema) {
+      return;
+    }
+    if (this.schema.hasOwnProperty('Q:options')) {
+      this.options = Object.assign(this.options, this.schema['Q:options']);
+    }
+  }
+
+  async attached() {
+    // if window.Dropzone is not defined, we load it async here using the aurelia loader
+    // as we need Dropzone later, we need to await the loading
+    if (!window.Dropzone) {
+      try {
+        window.Dropzone = await this.loader.loadModule('dropzone');
+        this.loader.loadModule('npm:dropzone@5.2.0/dist/min/dropzone.min.css!');
+      } catch (e) {
+        log.error(e);
+      }
+    }
+    if (!window.Dropzone) {
+      log.error('window.Dropzone is not defined after loading dropzone');
+      return;
+    }
+
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
+
+    const translations = {
+      "dictDefaultMessage": this.i18n.tr('dropzone.dictDefaultMessage'),
+      "dictFallbackMessage": this.i18n.tr('dropzone.dictFallbackMessage'),
+      "dictFallbackText": this.i18n.tr('dropzone.dictFallbackText'),
+      "dictFileTooBig": this.i18n.tr('dropzone.dictFileTooBig'),
+      "dictInvalidFileType": this.i18n.tr('dropzone.dictInvalidFileType'),
+      "dictResponseError": this.i18n.tr('dropzone.dictResponseError'),
+      "dictCancelUpload": this.i18n.tr('dropzone.dictCancelUpload'),
+      "dictCancelUploadConfirmation": this.i18n.tr('dropzone.dictCancelUploadConfirmation'),
+      "dictRemoveFile": this.i18n.tr('dropzone.dictRemoveFile'),
+      "dictMaxFilesExceeded": this.i18n.tr('dropzone.dictMaxFilesExceeded')
+    }
+
+    const dropzoneOptions = Object.assign({
+      addRemoveLinks: true,
+      url: `${QServerBaseUrl}/file/upload`,
+      headers: {
+        "Authorization": `${this.authService.config.authTokenType} ${this.authService.getAccessToken()}`
+      }
+    }, this.options, translations);
+
+    this.dropzone = new window.Dropzone(this.dropzoneElement, dropzoneOptions);
+
+    this.dropzone.on('success', (file, response) => {
+      if (this.options.maxFiles && this.options.maxFiles === 1) {
+        this.data = response.url;
+      } else {
+        if (!Array.isArray(this.data)) {
+          this.data = [];
+        }
+        this.data.push(response.url);
+      }
+      // the originalUrl property is used when deleting a file to delete it as well from the data
+      file.originalUrl = response.url;
+    });
+
+    this.dropzone.on('removedfile', (file) => {
+      if (Array.isArray(this.data)) {
+        this.data.splice(this.data.indexOf(file.originalUrl), 1);
+      } else {
+        this.data = undefined;
+      }
+    });
+
+    this.dropzone.on('maxfilesexceeded', (file) => {
+      this.dropzone.removeFile(file);
+      this.notification.error('notifications.maxNumberOfFilesExceed');
+    });
+
+    this.preloadExistingFiles();
+  }
+
+  preloadExistingFiles() {
+    const fileUrls = [];
+    if (this.data && this.schema.type === 'string') {
+      fileUrls.push(this.data);
+    }
+    if (this.data && this.schema.type === 'array' && this.data.length > 0) {
+      fileUrls.push(...this.data);
+    }
+    // preload images already uploaded
+    for (let fileUrl of fileUrls) {
+      const mockFile = {
+        name: fileUrl,
+        dataURL: fileUrl, // needed for dropzone to create the thumbnail in a canvas
+        originalUrl: fileUrl, // the originalUrl property is used when deleting a file to delete it as well from the data
+        size: 0,
+        accepted: true
+      }
+      this.dropzone.files.push(mockFile);
+      this.dropzone.emit('addedfile', mockFile);
+      this.dropzone.createThumbnailFromUrl(mockFile, 120, 120, 'crop', false, thumbnail => {
+        this.dropzone.emit("thumbnail", mockFile, thumbnail);
+        this.dropzone.emit("complete", mockFile);
+        this.dropzone.emit("accepted", mockFile);
+        this.dropzone._updateMaxFilesReachedClass();
+      }, 'anonymous');
+    }
+  }
+
+}

--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -72,7 +72,7 @@ export class SchemaEditorFiles {
 
     const dropzoneOptions = Object.assign({
       addRemoveLinks: true,
-      url: `${QServerBaseUrl}/file/upload`,
+      url: `${QServerBaseUrl}/file`,
       headers: {
         "Authorization": `${this.authService.config.authTokenType} ${this.authService.getAccessToken()}`
       }

--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -83,11 +83,13 @@ export class SchemaEditorFiles {
     this.dropzone.on('success', (file, response) => {
       if (this.options.maxFiles && this.options.maxFiles === 1) {
         this.data = response.url;
+        this.change();
       } else {
         if (!Array.isArray(this.data)) {
           this.data = [];
         }
         this.data.push(response.url);
+        this.change();
       }
       // the originalUrl property is used when deleting a file to delete it as well from the data
       file.originalUrl = response.url;
@@ -96,8 +98,10 @@ export class SchemaEditorFiles {
     this.dropzone.on('removedfile', (file) => {
       if (Array.isArray(this.data)) {
         this.data.splice(this.data.indexOf(file.originalUrl), 1);
+        this.change();
       } else {
         this.data = undefined;
+        this.change();
       }
     });
 

--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -81,10 +81,17 @@ export class SchemaEditorFiles {
     this.dropzone = new window.Dropzone(this.dropzoneElement, dropzoneOptions);
 
     this.dropzone.on('success', (file, response) => {
-      const newFile = {
-        url: response.url,
-        key: response.key
-      };
+      const newFile = {};
+      const fileProperties = Object.assign(file, response);
+      for (let prop in this.options.fileProperties) {
+        // fileProperties option is a mapping like this
+        // {
+        //   "url": "imageUrl"
+        // }
+        // where url is the prop returned in the response and imageUrl is the prop of the data object to hold that value;
+        // prop would be url in that example
+        newFile[this.options.fileProperties[prop]] = fileProperties[prop];
+      }
       if (this.options.maxFiles && this.options.maxFiles === 1) {
         this.data = newFile;
         this.change();
@@ -95,7 +102,7 @@ export class SchemaEditorFiles {
         this.data.push(newFile);
         this.change();
 
-        // the originalUrl property is used when deleting a file to delete it as well from the data
+        // the dataArrayIndex property is used when deleting a file to delete it as well from the data
         file.dataArrayIndex = this.data.indexOf(newFile);
       }
     });

--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -58,23 +58,23 @@ export class SchemaEditorFiles {
     const QServerBaseUrl = await qEnv.QServerBaseUrl;
 
     const translations = {
-      "dictDefaultMessage": this.i18n.tr('dropzone.dictDefaultMessage'),
-      "dictFallbackMessage": this.i18n.tr('dropzone.dictFallbackMessage'),
-      "dictFallbackText": this.i18n.tr('dropzone.dictFallbackText'),
-      "dictFileTooBig": this.i18n.tr('dropzone.dictFileTooBig'),
-      "dictInvalidFileType": this.i18n.tr('dropzone.dictInvalidFileType'),
-      "dictResponseError": this.i18n.tr('dropzone.dictResponseError'),
-      "dictCancelUpload": this.i18n.tr('dropzone.dictCancelUpload'),
-      "dictCancelUploadConfirmation": this.i18n.tr('dropzone.dictCancelUploadConfirmation'),
-      "dictRemoveFile": this.i18n.tr('dropzone.dictRemoveFile'),
-      "dictMaxFilesExceeded": this.i18n.tr('dropzone.dictMaxFilesExceeded')
-    }
+      'dictDefaultMessage': this.i18n.tr('dropzone.dictDefaultMessage'),
+      'dictFallbackMessage': this.i18n.tr('dropzone.dictFallbackMessage'),
+      'dictFallbackText': this.i18n.tr('dropzone.dictFallbackText'),
+      'dictFileTooBig': this.i18n.tr('dropzone.dictFileTooBig'),
+      'dictInvalidFileType': this.i18n.tr('dropzone.dictInvalidFileType'),
+      'dictResponseError': this.i18n.tr('dropzone.dictResponseError'),
+      'dictCancelUpload': this.i18n.tr('dropzone.dictCancelUpload'),
+      'dictCancelUploadConfirmation': this.i18n.tr('dropzone.dictCancelUploadConfirmation'),
+      'dictRemoveFile': this.i18n.tr('dropzone.dictRemoveFile'),
+      'dictMaxFilesExceeded': this.i18n.tr('dropzone.dictMaxFilesExceeded')
+    };
 
     const dropzoneOptions = Object.assign({
       addRemoveLinks: true,
       url: `${QServerBaseUrl}/file`,
       headers: {
-        "Authorization": `${this.authService.config.authTokenType} ${this.authService.getAccessToken()}`
+        'Authorization': `${this.authService.config.authTokenType} ${this.authService.getAccessToken()}`
       }
     }, this.options, translations);
 
@@ -129,13 +129,13 @@ export class SchemaEditorFiles {
         originalUrl: fileUrl, // the originalUrl property is used when deleting a file to delete it as well from the data
         size: 0,
         accepted: true
-      }
+      };
       this.dropzone.files.push(mockFile);
       this.dropzone.emit('addedfile', mockFile);
       this.dropzone.createThumbnailFromUrl(mockFile, 120, 120, 'crop', false, thumbnail => {
-        this.dropzone.emit("thumbnail", mockFile, thumbnail);
-        this.dropzone.emit("complete", mockFile);
-        this.dropzone.emit("accepted", mockFile);
+        this.dropzone.emit('thumbnail', mockFile, thumbnail);
+        this.dropzone.emit('complete', mockFile);
+        this.dropzone.emit('accepted', mockFile);
         this.dropzone._updateMaxFilesReachedClass();
       }, 'anonymous');
     }

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -139,4 +139,13 @@
       change.bind="change"
       required.bind="required"></schema-editor-table>
   </div>
+
+  <div if.bind="getType(schema) === 'files'" class="schema-editor-block">
+    <require from="./schema-editor-files"></require>
+    <schema-editor-files
+      schema.bind="schema"
+      data.two-way="data"
+      change.bind="change"
+      required.bind="required"></schema-editor-files>
+  </div>
 </template>


### PR DESCRIPTION
Use this in a schema like this:

```
{
  "type": "array",
  "Q:type": "files",
  "Q:options": {
    "acceptedFiles": "image/*"
    "fileProperties": {
      "url": "url",
      "key": "key",
      "size": "size",
      "width": "width",
      "height": "height"
    }
  },
  "items": {
    "type": "object"
  }
}
```

or like this
```
{
  "type": "object",
  "Q:type": "files",
  "Q:options": {
    "maxFiles": 1,
    "acceptedFiles": "image/*",
    "fileProperties": {
      "url": "url",
      "key": "key",
      "size": "size",
      "width": "width",
      "height": "height"
    }
  }
}
```

The property needs to be an object if `maxFiles` is 1, otherwise it needs to be an array of objects.
`maxFiles` is optional in this case and defaults to no limit.

What gets stored is an object/array of objects with the properties mapped in `fileProperties` option. So in this example it would be something like
```
{
  "url": "http://example.com/some-path-to-the-file.jpg",
  "key": "some-path-to-the-file.jpg",
  "size": 123456,
  "width": 1000,
  "height": 1000
}
```

This needs a Q server with https://github.com/nzzdev/Q-server/pull/101 to work.
  