### PR TITLE
(schema-editor) use opencagedata instead of mapzen as geocoding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const editorConfig = {
     //    publicationLastUpdated: '' // something Date.parse() understands
     //  }
     // ]
-    articlesWithItem: { 
+    articlesWithItem: {
       endpoint: {
         path: 'meta/articles-with-item/{id}'
       }
@@ -157,8 +157,7 @@ See the file `client/env`. This is loaded for development only and "fakes" the e
   "QServerBaseUrl": "http://localhost:3001",
   "loginMessage": "some text to be shown on the login screen",
   "devLogging": true,
-  "pushState": false,
-  "mapzenApiKey": "your mapzen api key, get it from https://mapzen.com. Only needed for geocoders in schema-editor-geojson-point"
+  "pushState": false
 }
 ```
 where `QServerBaseUrl` is a url to a running [Q server](https://github.com/nzzdev/Q-server).

--- a/client/config.js
+++ b/client/config.js
@@ -6,6 +6,7 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
+
   map: {
     "ajv": "npm:ajv@5.3.0",
     "array2d": "npm:array2d@0.0.5",
@@ -47,6 +48,7 @@ System.config({
     "i18next-fetch-backend": "npm:i18next-fetch-backend@0.0.1",
     "leaflet": "npm:leaflet@1.2.0",
     "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
+    "leaflet-search": "npm:leaflet-search@2.3.7",
     "text": "github:systemjs/plugin-text@0.0.8",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.4.1"
@@ -326,6 +328,9 @@ System.config({
       "leaflet": "npm:leaflet@1.2.0",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:leaflet-search@2.3.7": {
+      "leaflet": "npm:leaflet@1.2.0"
     },
     "npm:numbro@1.11.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"

--- a/client/env
+++ b/client/env
@@ -2,6 +2,5 @@
   "QServerBaseUrl": "http://localhost:3001",
   "loginMessage": "login message",
   "devLogging": true,
-  "pushState": false,
-  "mapzenApiKey": ""
+  "pushState": false
 }

--- a/client/package.json
+++ b/client/package.json
@@ -76,6 +76,7 @@
       "i18next-fetch-backend": "npm:i18next-fetch-backend@^0.0.1",
       "leaflet": "npm:leaflet@1.2.0",
       "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
+      "leaflet-search": "npm:leaflet-search@^2.3.7",
       "text": "github:systemjs/plugin-text@^0.0.8"
     },
     "devDependencies": {}

--- a/client/src/elements/atoms/button-no.html
+++ b/client/src/elements/atoms/button-no.html
@@ -1,4 +1,4 @@
-<template bindable="icon, code, size, iconSize" class="button">
+<template bindable="icon, code, size, iconSize, type" class="button">
   <require from="./button-no.css"></require>
   <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-no.html
+++ b/client/src/elements/atoms/button-no.html
@@ -1,4 +1,4 @@
 <template bindable="icon, code, size, iconSize, type" class="button">
   <require from="./button-no.css"></require>
-  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize"><slot></slot></icon-button>
+  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" type.bind="type"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-primary.html
+++ b/client/src/elements/atoms/button-primary.html
@@ -1,4 +1,4 @@
 <template bindable="icon, code, size, iconSize, tabindex, type" class="button">
   <require from="./button-primary.css"></require>
-  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex"><slot></slot></icon-button>
+  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex" type.bind="type"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-primary.html
+++ b/client/src/elements/atoms/button-primary.html
@@ -1,4 +1,4 @@
-<template bindable="icon, code, size, iconSize, tabindex" class="button">
+<template bindable="icon, code, size, iconSize, tabindex, type" class="button">
   <require from="./button-primary.css"></require>
   <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-secondary.html
+++ b/client/src/elements/atoms/button-secondary.html
@@ -1,4 +1,4 @@
-<template bindable="icon, code, size, iconSize, tabindex" class="button">
+<template bindable="icon, code, size, iconSize, tabindex, type" class="button">
   <require from="./button-secondary.css"></require>
   <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-secondary.html
+++ b/client/src/elements/atoms/button-secondary.html
@@ -1,4 +1,4 @@
 <template bindable="icon, code, size, iconSize, tabindex, type" class="button">
   <require from="./button-secondary.css"></require>
-  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex"><slot></slot></icon-button>
+  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex" type.bind="type"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-tertiary.html
+++ b/client/src/elements/atoms/button-tertiary.html
@@ -1,4 +1,4 @@
 <template bindable="icon, code, size, iconSize, tabindex" class="button">
   <require from="./button-tertiary.css"></require>
-  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex"><slot></slot></icon-button>
+  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex" type.bind="type"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-yes.html
+++ b/client/src/elements/atoms/button-yes.html
@@ -1,4 +1,4 @@
 <template bindable="icon, code, size, iconSize, tabindex, type" class="button">
   <require from="./button-yes.css"></require>
-  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex"><slot></slot></icon-button>
+  <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex" type.bind="type"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/button-yes.html
+++ b/client/src/elements/atoms/button-yes.html
@@ -1,4 +1,4 @@
-<template bindable="icon, code, size, iconSize, tabindex" class="button">
+<template bindable="icon, code, size, iconSize, tabindex, type" class="button">
   <require from="./button-yes.css"></require>
   <icon-button icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex"><slot></slot></icon-button>
 </template>

--- a/client/src/elements/atoms/icon-button.html
+++ b/client/src/elements/atoms/icon-button.html
@@ -1,6 +1,6 @@
-<template bindable="icon, code, size, iconSize, tabindex" class="size-${size}">
+<template class="size-${size}">
   <require from="./icon-button.css"></require>
-  <button tabindex.bind="tabindex">
+  <button tabindex.bind="tabindex" type.bind="type">
     <span class="icon-button__icon">
       <box-icon if.bind="code || icon" code.bind="code" icon.bind="icon" size="${iconSize || size}"></box-icon>
     </span>

--- a/client/src/elements/atoms/icon-button.js
+++ b/client/src/elements/atoms/icon-button.js
@@ -5,14 +5,8 @@ export class IconButton {
   @bindable icon
   @bindable code
   @bindable size
+  @bindable iconSize
+  @bindable tabindex
+  @bindable type = 'button'
 
-  created(owningView, myView) {
-    this.view = myView;
-  }
-
-  attached() {
-    if (this.view.slots['__au-default-slot-key__'].children.length > 0) {
-      this.hasText = true;
-    }
-  }
 }

--- a/client/src/elements/atoms/index.js
+++ b/client/src/elements/atoms/index.js
@@ -6,6 +6,6 @@ export function configure(frameworkConfiguration) {
     .globalResources('./button-secondary.html')
     .globalResources('./button-tertiary.html')
     .globalResources('./button-yes.html')
-    .globalResources('./icon-button.html')
+    .globalResources('./icon-button.js')
     .globalResources('./q-loader.html');
 }

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.css
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.css
@@ -10,16 +10,67 @@ schema-editor-geojson-point .lat-lng-input label {
   flex-grow: 1;
 }
 
-schema-editor-geojson-point .leaflet-pelias-input {
-  padding: 0 0 0 26px;
+schema-editor-geojson-point .leaflet-top.leaflet-left {
+  width: 100%;
 }
 
-schema-editor-geojson-point .leaflet-pelias-expanded .leaflet-pelias-input {
-  padding-right: 30px; /* Space for close button */
+schema-editor-geojson-point .leaflet-control-search {
+  width: 100%;
+  margin: 0 !important;
+  padding: 10px;
+}
 
-  /* The properties below should be tweaked if height of .leaflet-pelias-expanded is changed */
-  padding-top: 5px;
-  padding-bottom: 5px;
+schema-editor-geojson-point .leaflet-control-search .search-input {
+  width: 90%;
+  padding-right: 60px;
+}
+
+schema-editor-geojson-point .leaflet-control-search .search-cancel {
+  position: absolute;
+  top: 14px;
+  right: 60px;
+  font-size: 20px;
+  color: black;
+  text-decoration: none;
+}
+
+schema-editor-geojson-point .leaflet-control-search .search-button {
+  width: 37px;
+  height: 37px;
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  text-align: center;
+  text-decoration: none;
+  background: var(--q-color-white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid rgba(0,0,0,0.2);
+  border-radius: 2px;
+}
+
+schema-editor-geojson-point .leaflet-control-search .search-button::before {
+  content: '🔍';
+  display: block;
+  font-size: 20px;
+}
+
+schema-editor-geojson-point .leaflet-control-search ul.search-tooltip {
+  margin: 5px 0 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+schema-editor-geojson-point .leaflet-control-search .search-tip {
+  padding: 10px;
+  background: var(--q-color-white);
+  cursor: pointer;
+}
+
+schema-editor-geojson-point .leaflet-control-search .search-tip-select,
+schema-editor-geojson-point .leaflet-control-search .search-tip:hover {
+  background: var(--q-color-primary-1);
 }
 
 schema-editor-geojson-point .leaflet-areaselect-container {

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.css
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.css
@@ -28,7 +28,7 @@ schema-editor-geojson-point .leaflet-control-search .search-input {
 schema-editor-geojson-point .leaflet-control-search .search-cancel {
   position: absolute;
   top: 14px;
-  right: 60px;
+  right: 70px;
   font-size: 20px;
   color: black;
   text-decoration: none;

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.js
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.js
@@ -156,7 +156,11 @@ export class SchemaEditorGeojsonPoint {
 
         if (selected && selected.properties) {
           try {
-            this.data.properties.label = selected.properties.components[selected.properties.components._type];
+            if (selected.properties.components[selected.properties.components._type]) {
+              this.data.properties.label = selected.properties.components[selected.properties.components._type];
+            } else {
+              throw new Error('property not available');
+            }
           } catch (e) {
             this.data.properties.label = selected.properties.formatted;
           }

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.js
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.js
@@ -113,7 +113,6 @@ export class SchemaEditorGeojsonPoint {
           return records; // do not filter the results
         },
         formatData: (data) => {
-          console.log(data);
           return data.features
             .filter(result => {
               return result.geometry.type === 'Point';
@@ -122,12 +121,12 @@ export class SchemaEditorGeojsonPoint {
               return {
                 label: result.properties.formatted,
                 location: [result.geometry.coordinates[1], result.geometry.coordinates[0]]
-              }
+              };
             })
             .reduce((allResults, result) => {
               allResults[result.label] = result.location;
               return allResults;
-            }, {})
+            }, {});
         },
         minLength: 3,
         autoCollapse: true,
@@ -138,7 +137,7 @@ export class SchemaEditorGeojsonPoint {
       this.geocoder.on('search:locationfound', (selectedSearchResult) => {
         this.data.geometry = {
           coordinates: [selectedSearchResult.latlng[1], selectedSearchResult.latlng[0]]
-        }
+        };
         this.data.properties.label = selectedSearchResult.text;
         if (this.change) {
           this.change();
@@ -307,10 +306,7 @@ export class SchemaEditorGeojsonPoint {
 
 
 function geocode(searchTerm, apiKey, language) {
-  const query = {
-    q: searchTerm
-  }
-  const api = `https://api.opencagedata.com/geocode/v1/geojson?q=${searchTerm}&key=${apiKey}&language=${language}`
+  const api = `https://api.opencagedata.com/geocode/v1/geojson?q=${searchTerm}&key=${apiKey}&language=${language}`;
   return fetch(api)
     .then(res => {
       if (!res.ok) {

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.js
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.js
@@ -1,6 +1,5 @@
 import { bindable, inject, Loader, LogManager } from 'aurelia-framework';
 import { checkAvailability } from 'resources/schemaEditorDecorators.js';
-import qEnv from 'resources/qEnv';
 import QConfig from 'resources/QConfig';
 import { isRequired } from './helpers.js';
 
@@ -50,6 +49,8 @@ export class SchemaEditorGeojsonPoint {
   }
 
   async attached() {
+    const schemaEditorConfig = await this.qConfig.get('schemaEditor');
+
     this.showLoadingError = false;
 
     // if we already have a map, return here
@@ -74,19 +75,13 @@ export class SchemaEditorGeojsonPoint {
       return;
     }
 
-    // if we do not have a Leaflet.control.geocoder yet, we load the module async using the aurelia loader
-    // this failed in some tests because of weird module format. But it worked always, so we ignore any loading error here...
-    if (!window.Leaflet.control.geocoder) {
-      try {
-        this.loader.loadModule('npm:leaflet-geocoder-mapzen@1.8.0/dist/leaflet-geocoder-mapzen.css!');
-        await this.loader.loadModule('leaflet-geocoder-mapzen');
-      } catch (e) {
-        // leaflet-geocoder-mapzen is probably loaded, nevermind the error here
-      }
+    // if we do not have a Leaflet.Control.Search yet, we load the module async using the aurelia loader
+    if (!window.Leaflet.Control.Search) {
+      await this.loader.loadModule('leaflet-search');
     }
-    // ... test again if it's here
-    if (!window.Leaflet.control.geocoder) {
-      log.error('window.Leaflet.control.geocoder is not defined after loading leaflet-geocoder-mapzen');
+
+    if (!window.Leaflet.Control.Search) {
+      log.error('window.Leaflet.Control.Search is not defined after loading leaflet-search');
       this.showLoadingError = true;
       return;
     }
@@ -106,23 +101,45 @@ export class SchemaEditorGeojsonPoint {
       scrollWheelZoom: 'center'
     }).setView([47.36521171867246, 8.547435700893404], 13);
 
-    // we need a mapzen key for the geocoder, this has to be defined in ENV
-    // if it's not here, we do not add a geocoder
-    const mapzenApiKey = await qEnv.mapzenApiKey;
-    if (mapzenApiKey === undefined) {
-      log.info('no mapzenApiKey defined, will not load geocoder for geojson-point editor');
+    if (!schemaEditorConfig.geojson.opencagedata.apiKey) {
+      log.info('no opencageApiKey given, will not load geocoder for geojson-point editor');
     } else {
-      this.geocoder = window.Leaflet.control.geocoder(mapzenApiKey, {
-        attribution: null,
-        fullWidth: true,
-        markers: false,
-        focus: false
+      this.geocoder = new window.Leaflet.Control.Search({
+        sourceData: async (text, next) => {
+          const data = await geocode(text, schemaEditorConfig.geojson.opencagedata.apiKey, schemaEditorConfig.geojson.opencagedata.language);
+          next(data);
+        },
+        filterData: (value, records) => {
+          return records; // do not filter the results
+        },
+        formatData: (data) => {
+          console.log(data);
+          return data.features
+            .filter(result => {
+              return result.geometry.type === 'Point';
+            })
+            .map(result => {
+              return {
+                label: result.properties.formatted,
+                location: [result.geometry.coordinates[1], result.geometry.coordinates[0]]
+              }
+            })
+            .reduce((allResults, result) => {
+              allResults[result.label] = result.location;
+              return allResults;
+            }, {})
+        },
+        minLength: 3,
+        autoCollapse: true,
+        marker: false,
+        textPlaceholder: ''
       });
 
-      this.geocoder.on('select', e => {
-        this.geocoder.collapse();
-        this.data.geometry = e.feature.geometry;
-        this.data.properties.label = e.feature.properties.name;
+      this.geocoder.on('search:locationfound', (selectedSearchResult) => {
+        this.data.geometry = {
+          coordinates: [selectedSearchResult.latlng[1], selectedSearchResult.latlng[0]]
+        }
+        this.data.properties.label = selectedSearchResult.text;
         if (this.change) {
           this.change();
         }
@@ -145,7 +162,6 @@ export class SchemaEditorGeojsonPoint {
       }
     });
 
-    const schemaEditorConfig = await this.qConfig.get('schemaEditor');
     const layerConfig = schemaEditorConfig.geojson.layer;
 
     if (this.map) {
@@ -287,4 +303,25 @@ export class SchemaEditorGeojsonPoint {
       this.areaSelect.setDimensions({width: width, height: (width / 16) * 9});
     }
   }
+}
+
+
+function geocode(searchTerm, apiKey, language) {
+  const query = {
+    q: searchTerm
+  }
+  const api = `https://api.opencagedata.com/geocode/v1/geojson?q=${searchTerm}&key=${apiKey}&language=${language}`
+  return fetch(api)
+    .then(res => {
+      if (!res.ok) {
+        throw new Error(res);
+      }
+      return res.json();
+    })
+    .then(data => {
+      return data;
+    })
+    .catch(e => {
+      // fail silent
+    });
 }

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.js
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.js
@@ -135,7 +135,9 @@ export class SchemaEditorGeojsonPoint {
       });
 
       this.geocoder.on('search:locationfound', (selectedSearchResult) => {
+        console.log(selectedSearchResult);
         this.data.geometry = {
+          type: 'Point',
           coordinates: [selectedSearchResult.latlng[1], selectedSearchResult.latlng[0]]
         };
         this.data.properties.label = selectedSearchResult.text;

--- a/client/src/pages/login.html
+++ b/client/src/pages/login.html
@@ -19,7 +19,7 @@
       <p class="q-text q-text--error" if.bind="loginError">
         ${loginError}
       </p>
-      <button-primary click.delegate="tryLogin()"><span t="general.login"></span></button-primary>
+      <button-primary click.delegate="tryLogin()" type="submit"><span t="general.login"></span></button-primary>
     </form>
   </main>
 </template>


### PR DESCRIPTION
this changes the geocoding provider to opencagedata because mapzen is shutting down.
this needs the following editor config delivered from Q server:
```
schemaEditor: {
  geojson: {
    layer: {...}
    opencagedata: {
      apiKey: '',
      language: ''
    }
  }
}
```