### PR TITLE
(schema-editor) input placeholder configurabel via Q:options

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-link.html
+++ b/client/src/elements/schema-editor/schema-editor-link.html
@@ -1,6 +1,6 @@
 <template>
   <label>
     ${schema.properties.url["title"] || ''}
-    <input type="url" required.bind="required" value.bind="data.url" ref="urlInput" keyup.delegate="handleUrlChange() & debounce:800">
+    <input type="url" placeholder.to-view="options.placeholder || ''" required.bind="required" value.bind="data.url" ref="urlInput" keyup.delegate="handleUrlChange() & debounce:800">
   <label>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-link.js
+++ b/client/src/elements/schema-editor/schema-editor-link.js
@@ -1,13 +1,24 @@
-import { bindable } from 'aurelia-framework';
-import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+import { bindable } from "aurelia-framework";
+import { checkAvailability } from "resources/schemaEditorDecorators.js";
 
 @checkAvailability()
 export class SchemaEditorLink {
+  @bindable data;
+  @bindable schema;
+  @bindable change;
+  @bindable required;
 
-  @bindable data
-  @bindable schema
-  @bindable change
-  @bindable required
+  options = {};
+
+  schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
+  }
 
   handleUrlChange() {
     if (this.urlInput.validity.valid) {
@@ -16,6 +27,4 @@ export class SchemaEditorLink {
     }
     this.change();
   }
-
-
 }

--- a/client/src/elements/schema-editor/schema-editor-number.html
+++ b/client/src/elements/schema-editor/schema-editor-number.html
@@ -1,6 +1,6 @@
 <template class="schema-editor-input">
   <label>
     ${schema["title"]}
-    <input type="number" required.bind="required" value.bind="data | forceNumber" step.bind="options.step" keyup.delegate="change() & debounce:800">
+    <input type="number" placeholder.to-view="options.placeholder || ''" required.bind="required" value.bind="data | forceNumber" step.bind="options.step" keyup.delegate="change() & debounce:800">
   <label>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-string.html
+++ b/client/src/elements/schema-editor/schema-editor-string.html
@@ -1,6 +1,6 @@
 <template class="schema-editor-input">
   <label>
     ${schema["title"]}
-    <input type="text" value.bind="data" required.bind="required" keyup.delegate="change() & debounce:800">
+    <input type="text" placeholder.to-view="options.placeholder || ''" value.bind="data" required.bind="required" keyup.delegate="change() & debounce:800">
   </label>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-string.js
+++ b/client/src/elements/schema-editor/schema-editor-string.js
@@ -1,12 +1,22 @@
-import { bindable } from 'aurelia-framework';
-import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+import { bindable } from "aurelia-framework";
+import { checkAvailability } from "resources/schemaEditorDecorators.js";
 
 @checkAvailability()
 export class SchemaEditorString {
-
   @bindable schema;
   @bindable data;
   @bindable change;
   @bindable required;
 
+  options = {};
+
+  schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
+  }
 }

--- a/client/src/elements/schema-editor/schema-editor-textarea.html
+++ b/client/src/elements/schema-editor/schema-editor-textarea.html
@@ -1,6 +1,6 @@
 <template class="schema-editor-input">
   <label>
     ${schema["title"]}
-    <textare value.bind="data" required.bind="required" input.delegate="change() & debounce:800"></textare>
+    <textare value.bind="data" placeholder.to-view="options.placeholder || ''" required.bind="required" input.delegate="change() & debounce:800"></textare>
   </label>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-textarea.js
+++ b/client/src/elements/schema-editor/schema-editor-textarea.js
@@ -1,12 +1,20 @@
-import { bindable } from 'aurelia-framework';
-import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+import { bindable } from "aurelia-framework";
+import { checkAvailability } from "resources/schemaEditorDecorators.js";
 
 @checkAvailability()
 export class SchemaEditorTextarea {
-
   @bindable schema;
   @bindable data;
   @bindable change;
   @bindable required;
 
+  schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
+  }
 }

--- a/client/src/elements/schema-editor/schema-editor-url.html
+++ b/client/src/elements/schema-editor/schema-editor-url.html
@@ -1,6 +1,6 @@
 <template>
   <label>
     ${schema["title"]}
-    <input type="url" required.bind="required" value.bind="data" keyup.delegate="change() & debounce:800">
+    <input type="url" placeholder.to-view="options.placeholder || ''" required.bind="required" value.bind="data" keyup.delegate="change() & debounce:800">
   <label>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-url.js
+++ b/client/src/elements/schema-editor/schema-editor-url.js
@@ -1,12 +1,20 @@
-import { bindable } from 'aurelia-framework';
-import { checkAvailability } from 'resources/schemaEditorDecorators.js';
+import { bindable } from "aurelia-framework";
+import { checkAvailability } from "resources/schemaEditorDecorators.js";
 
 @checkAvailability()
 export class SchemaEditorUrl {
-
   @bindable schema;
   @bindable data;
   @bindable change;
   @bindable required;
 
+  schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
+  }
 }

--- a/client/src/styles/q-form.css
+++ b/client/src/styles/q-form.css
@@ -2,6 +2,10 @@
   margin-top: calc(var(--q-space-base) * 2);
 }
 
+.q-form ::placeholder {
+  color: var(--q-text-ultralight-color)
+}
+
 .q-form label {
   font-size: var(--q-text-small-size);
   line-height: 1.33;
@@ -43,7 +47,7 @@
   opacity: 0.5;
 }
 
-.q-form input[type="text"], 
+.q-form input[type="text"],
 .q-form input[type="url"] {
   font-size: 14px;
   line-height: 1.3;


### PR DESCRIPTION
implements: https://github.com/nzzdev/Q-editor/issues/46

Placeholder is configurable via Q:options like this:

```
"someProperty": {
  "title": "",
  "type": "number",
  "Q:options": {
    "placeholder": "123"
  }
},
```