### PR TITLE
Feat confirm before edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ const editorConfig = {
   },
   uiBehavior: {
     useItemDialogToActivate: true // if false, item is directly activatable from tool-status-bar (default: true)
+    askBeforeEditIfActive: { // if given the editor will ask users before editing an active item that was last editor longer than lastEditSecondsThreshold before
+      lastEditSecondsThreshold: 60 * 60 * 6 // 6 hours
+    }
   },
   eastereggs: { // there are some eastereggs in Q. provide the urls to the soundfiles here. We do not distribute them because we do not have the copyright for the tunes we use at NZZ.
     sounds: {

--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -36,8 +36,8 @@
   "editor": {
     "questionLeaveWithUnsavedChanges": "Es sind nicht alle Änderungen gespeichert, trotzdem schliessen?",
     "questionReallyEditBecauseActive": "Diese Grafik ist bereits aktiv. Änderungen werden in allen Artikel übernommen. Willst du diese Grafik wirklich editieren?",
-    "confirmProceedToEditor": "Ja, ich möchte diese Grafik editieren",
-    "cancelProceedToEditor": "Nein, das möchte ich nicht",
+    "confirmProceedToEditor": "Ja, weiter zum Editor",
+    "cancelProceedToEditor": "Nein, abbrechen",
     "arrayEntryAdd": "{{ arrayEntryLabel }} hinzufügen",
     "activatingEditorTakesTooLong": "Es dauert zu lange den Editor zu laden, irgendwas ist schief gelaufen.",
     "failedToSave": "Speichern ist fehlgeschlagen",

--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -35,6 +35,9 @@
   },
   "editor": {
     "questionLeaveWithUnsavedChanges": "Es sind nicht alle Änderungen gespeichert, trotzdem schliessen?",
+    "questionReallyEditBecauseActive": "Diese Grafik ist bereits aktiv. Änderungen werden in allen Artikel übernommen. Willst du diese Grafik wirklich editieren?",
+    "confirmProceedToEditor": "Ja, ich möchte diese Grafik editieren",
+    "cancelProceedToEditor": "Nein, das möchte ich nicht",
     "arrayEntryAdd": "{{ arrayEntryLabel }} hinzufügen",
     "activatingEditorTakesTooLong": "Es dauert zu lange den Editor zu laden, irgendwas ist schief gelaufen.",
     "failedToSave": "Speichern ist fehlgeschlagen",

--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -35,7 +35,7 @@
   },
   "editor": {
     "questionLeaveWithUnsavedChanges": "Es sind nicht alle Änderungen gespeichert, trotzdem schliessen?",
-    "questionReallyEditBecauseActive": "Diese Grafik ist bereits aktiv. Änderungen werden in allen Artikel übernommen. Willst du diese Grafik wirklich editieren?",
+    "questionReallyEditBecauseActive": "Diese Grafik ist bereits aktiv. Änderungen werden in allen Artikel übernommen. Willst du diese Grafik wirklich bearbeiten?",
     "confirmProceedToEditor": "Ja, weiter zum Editor",
     "cancelProceedToEditor": "Nein, abbrechen",
     "arrayEntryAdd": "{{ arrayEntryLabel }} hinzufügen",

--- a/client/locales/en/translation.json
+++ b/client/locales/en/translation.json
@@ -36,8 +36,8 @@
   "editor": {
     "questionLeaveWithUnsavedChanges": "Not all changes are saved, close anyway?",
     "questionReallyEditBecauseActive": "This graphic is already activ. Changes will be applied in all articles. Do you really want to edit this graphic?",
-    "confirmProceedToEditor": "Yes, I want to edit this graphic",
-    "cancelProceedToEditor": "No, I do not want to edit this graphic",
+    "confirmProceedToEditor": "Yes, proceed to editor",
+    "cancelProceedToEditor": "No, cancel",
     "arrayEntryAdd": "add {{ arrayEntryLabel }}",
     "activatingEditorTakesTooLong": "It takes too long to load the editor, something is wrong.",
     "failedToSave": "Failed to save",

--- a/client/locales/en/translation.json
+++ b/client/locales/en/translation.json
@@ -35,6 +35,9 @@
   },
   "editor": {
     "questionLeaveWithUnsavedChanges": "Not all changes are saved, close anyway?",
+    "questionReallyEditBecauseActive": "This graphic is already activ. Changes will be applied in all articles. Do you really want to edit this graphic?",
+    "confirmProceedToEditor": "Yes, I want to edit this graphic",
+    "cancelProceedToEditor": "No, I do not want to edit this graphic",
     "arrayEntryAdd": "add {{ arrayEntryLabel }}",
     "activatingEditorTakesTooLong": "It takes too long to load the editor, something is wrong.",
     "failedToSave": "Failed to save",

--- a/client/src/dialogs/confirm-dialog.html
+++ b/client/src/dialogs/confirm-dialog.html
@@ -5,8 +5,8 @@
       <h1 class="q-dialog-title">${config.confirmQuestion}</h1>
     </div>
     <div class="q-dialog__controls">
-      <button-yes click.delegate="controller.ok()">${'general.yes' & t}</button-yes>
-      <button-no click.delegate="controller.cancel()">${'general.no' & t}</button-yes>
+      <button-yes click.delegate="controller.ok()">${config.proceedText}</button-yes>
+      <button-no click.delegate="controller.cancel()">${config.cancelText}</button-yes>
     </div>
   </div>
 </template>

--- a/client/src/dialogs/confirm-dialog.js
+++ b/client/src/dialogs/confirm-dialog.js
@@ -1,14 +1,23 @@
-import { inject } from 'aurelia-framework';
-import { DialogController } from 'aurelia-dialog';
+import { inject } from "aurelia-framework";
+import { DialogController } from "aurelia-dialog";
+import { I18N } from "aurelia-i18n";
 
-@inject(DialogController)
+@inject(DialogController, I18N)
 export class ConfirmDialog {
-
-  constructor(controller) {
+  constructor(controller, i18n) {
     this.controller = controller;
+    this.i18n = i18n;
   }
 
   activate(config) {
     this.config = config;
+
+    if (!this.config.proceedText) {
+      this.config.proceedText = this.i18n.tr("general.yes");
+    }
+
+    if (!this.config.cancelText) {
+      this.config.cancelText = this.i18n.tr("general.no");
+    }
   }
 }

--- a/client/src/pages/item-overview.js
+++ b/client/src/pages/item-overview.js
@@ -73,7 +73,7 @@ export class ItemOverview {
     // ask the user if she really wants to edit this item
 
     // if the item is not active, go to the editor
-    if (this.item.conf.active === false) {
+    if (this.item.conf.active !== true) {
       this.router.navigate(editorRoute);
       return;
     }

--- a/client/src/pages/item-overview.js
+++ b/client/src/pages/item-overview.js
@@ -1,21 +1,42 @@
-import { inject } from 'aurelia-framework';
-import { Router } from 'aurelia-router';
-import { RelativeTime } from 'aurelia-i18n';
-import { I18N } from 'aurelia-i18n';
-import { Notification } from 'aurelia-notification';
-import { HttpClient } from 'aurelia-fetch-client';
+import { inject } from "aurelia-framework";
+import { Router } from "aurelia-router";
+import { DialogService } from "aurelia-dialog";
+import { ConfirmDialog } from "dialogs/confirm-dialog.js";
+import { RelativeTime } from "aurelia-i18n";
+import { I18N } from "aurelia-i18n";
+import { Notification } from "aurelia-notification";
+import { HttpClient } from "aurelia-fetch-client";
 
-import ItemStore from 'resources/ItemStore.js';
-import ToolsInfo from 'resources/ToolsInfo.js';
-import QConfig from 'resources/QConfig.js';
-import qEnv from 'resources/qEnv.js';
+import ItemStore from "resources/ItemStore.js";
+import ToolsInfo from "resources/ToolsInfo.js";
+import QConfig from "resources/QConfig.js";
+import qEnv from "resources/qEnv.js";
 
-@inject(Router, RelativeTime, I18N, Notification, HttpClient, ItemStore, ToolsInfo, QConfig)
+@inject(
+  Router,
+  RelativeTime,
+  I18N,
+  Notification,
+  HttpClient,
+  ItemStore,
+  ToolsInfo,
+  QConfig,
+  DialogService
+)
 export class ItemOverview {
-
   currentTarget;
 
-  constructor(router, relativeTime, i18n, notification, httpClient, itemStore, toolsInfo, qConfig) {
+  constructor(
+    router,
+    relativeTime,
+    i18n,
+    notification,
+    httpClient,
+    itemStore,
+    toolsInfo,
+    qConfig,
+    dialogService
+  ) {
     this.router = router;
     this.relativeTime = relativeTime;
     this.i18n = i18n;
@@ -24,6 +45,7 @@ export class ItemOverview {
     this.itemStore = itemStore;
     this.toolsInfo = toolsInfo;
     this.qConfig = qConfig;
+    this.dialogService = dialogService;
   }
 
   async activate(routeParams) {
@@ -31,31 +53,82 @@ export class ItemOverview {
       this.itemId = routeParams.id;
       this.item = await this.itemStore.getItem(routeParams.id);
     } catch (e) {
-      this.notification.error('notification.failedToLoadItem');
+      this.notification.error("notification.failedToLoadItem");
     }
   }
 
   async attached() {
-    this.isToolAvailable = await this.toolsInfo.isToolWithNameAvailable(this.item.conf.tool);
-    if (await this.qConfig.get('metaInformation')) {
+    this.isToolAvailable = await this.toolsInfo.isToolWithNameAvailable(
+      this.item.conf.tool
+    );
+    if (await this.qConfig.get("metaInformation")) {
       this.loadMetaInformation();
     }
   }
 
-  edit() {
-    let tool = this.item.conf.tool.replace(new RegExp('-', 'g'), '_');
-    this.router.navigate(`/editor/${tool}/${this.item.conf._id}`);
+  async edit() {
+    const editorRoute = `/editor/${this.item.conf.tool}/${this.item.conf._id}`;
+
+    // if the item is already active and the last edited and uiBehaviour.askBeforeEditIfActive is true in config, we
+    // ask the user if she really wants to edit this item
+
+    // if the item is not active, go to the editor
+    if (this.item.conf.active === false) {
+      this.router.navigate(editorRoute);
+      return;
+    }
+
+    // otherwise we need to load the uiBehaviour Configuration
+    const uiBehaviorConfig = await this.qConfig.get("uiBehavior");
+
+    // if we do not have the config, go to the editor
+    if (!uiBehaviorConfig || !uiBehaviorConfig.askBeforeEditIfActive) {
+      this.router.navigate(editorRoute);
+      return;
+    }
+
+    // otherwise compute the secondsSinceLastEdit
+    const lastEditedDate = new Date(this.item.conf.updatedDate || Date.now());
+    const now = new Date();
+    const secondsSinceLastEdit =
+      now.getTime() / 1000 - lastEditedDate.getTime() / 1000;
+
+    // if the configured threshold is not reached, go to the editor
+    if (
+      !uiBehaviorConfig.askBeforeEditIfActive.lastEditSecondsThreshold ||
+      secondsSinceLastEdit <
+        uiBehaviorConfig.askBeforeEditIfActive.lastEditSecondsThreshold
+    ) {
+      this.router.navigate(editorRoute);
+      return;
+    }
+
+    // open the dialog to ask the user if she wants to edit
+    const openDialogResult = await this.dialogService.open({
+      viewModel: ConfirmDialog,
+      model: {
+        confirmQuestion: this.i18n.tr("editor.questionReallyEditBecauseActive"),
+        proceedText: this.i18n.tr("editor.confirmProceedToEditor"),
+        cancelText: this.i18n.tr("editor.cancelProceedToEditor")
+      }
+    });
+    const closeResult = await openDialogResult.closeResult;
+
+    // only go to the editor if it was not cancelled
+    if (!closeResult.wasCancelled) {
+      this.router.navigate(editorRoute);
+    }
   }
 
   async blueprint() {
     try {
       await this.item.blueprint();
-      this.item.conf.title = this.i18n.tr('item.blueprintTitlePrefix');
+      this.item.conf.title = this.i18n.tr("item.blueprintTitlePrefix");
 
-      let tool = this.item.conf.tool.replace(new RegExp('-', 'g'), '_');
+      let tool = this.item.conf.tool.replace(new RegExp("-", "g"), "_");
       this.router.navigate(`/editor/${tool}/${this.item.conf._id}`);
     } catch (e) {
-      this.notification.error('notification.failedToLoadItem');
+      this.notification.error("notification.failedToLoadItem");
     }
   }
 
@@ -73,12 +146,18 @@ export class ItemOverview {
 
   async loadMetaInformation() {
     let QServerBaseUrl = await qEnv.QServerBaseUrl;
-    const metaInformationConfig = await this.qConfig.get('metaInformation');
+    const metaInformationConfig = await this.qConfig.get("metaInformation");
     let requestUrl;
-    if (metaInformationConfig.hasOwnProperty('articlesWithItem') && metaInformationConfig.articlesWithItem.hasOwnProperty('endpoint')) {
+    if (
+      metaInformationConfig.hasOwnProperty("articlesWithItem") &&
+      metaInformationConfig.articlesWithItem.hasOwnProperty("endpoint")
+    ) {
       const endpoint = metaInformationConfig.articlesWithItem.endpoint;
-      if (endpoint.hasOwnProperty('path')) {
-        requestUrl = `${QServerBaseUrl}/${endpoint.path}`.replace('{id}', this.item.id);
+      if (endpoint.hasOwnProperty("path")) {
+        requestUrl = `${QServerBaseUrl}/${endpoint.path}`.replace(
+          "{id}",
+          this.item.id
+        );
       }
       const response = await this.httpClient.fetch(requestUrl);
       if (!response.ok || response.status >= 400) {
@@ -87,5 +166,4 @@ export class ItemOverview {
       this.articlesWithItem = await response.json();
     }
   }
-
 }


### PR DESCRIPTION
This will ask the user if she really wants to edit if an item is active and has not been edited since a configurable amount of time before opening the editor from item-overview page.

it's deployed on staging for testing.