### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.2 (14.02.2018)
+- fix: do not try to parse the cookie to not fail on broken one as no cookie is needed
+
 # 1.7.1 (30.01.2018)
 - fix: display dropzone message in singular form if only one image is allowed
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ async function start() {
   try {
     const hapiOptions = {
       port: process.env.PORT || 8080,
-      load: { sampleInterval: 1000 }
+      load: { sampleInterval: 1000 },
+      state: { parse: false, failAction: "log" }
     };
 
     server = Hapi.server(hapiOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
hotfix: do not parse cookies as we do not need them and there was an error last night for someone with a probably broken cookie who was not able to embed a graphic because Q-editor returned with 400.