### PR TITLE
Move search implementation to q-server

### DIFF
--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -203,7 +203,7 @@ export class App {
   }
 
   updateMoreItemsAvailableState(result) {
-    if (result.total_rows > this.items.length) {
+    if (result.total_rows >= this.items.length) {
       this.moreItemsAvailable = true;
     } else {
       this.moreItemsAvailable = false;

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -1,9 +1,9 @@
-import { inject, singleton } from 'aurelia-framework';
-import { I18N } from 'aurelia-i18n';
-import ItemStore from 'resources/ItemStore.js';
-import QTargets from 'resources/QTargets.js';
-import qEnv from 'resources/qEnv.js';
-import ObjectFromSchemaGenerator from 'resources/ObjectFromSchemaGenerator.js';
+import { inject, singleton } from "aurelia-framework";
+import { I18N } from "aurelia-i18n";
+import ItemStore from "resources/ItemStore.js";
+import QTargets from "resources/QTargets.js";
+import qEnv from "resources/qEnv.js";
+import ObjectFromSchemaGenerator from "resources/ObjectFromSchemaGenerator.js";
 
 let loadedItems = [];
 
@@ -29,7 +29,6 @@ async function getItem(id) {
 @singleton()
 @inject(ItemStore, QTargets, ObjectFromSchemaGenerator, I18N)
 export class App {
-
   constructor(itemStore, qTargets, objectFromSchemaGenerator, i18n) {
     this.itemStore = itemStore;
     this.qTargets = qTargets;
@@ -67,7 +66,7 @@ export class App {
 
   async loadTarget() {
     try {
-      const targets = await this.qTargets.get('availableTargets');
+      const targets = await this.qTargets.get("availableTargets");
       this.target = targets.filter(target => {
         return target.key === this.targetKey;
       })[0];
@@ -95,10 +94,9 @@ export class App {
 
   loadSelectedItem(item) {
     this.title = item.conf.title;
-    const index = this.selectedItems
-      .findIndex(selectedItem => {
-        return selectedItem.id === item.conf._id;
-      });
+    const index = this.selectedItems.findIndex(selectedItem => {
+      return selectedItem.id === item.conf._id;
+    });
     if (index > -1) {
       this.selectedItemIndex = index;
     } else {
@@ -114,7 +112,8 @@ export class App {
 
   insertItem() {
     // delete all displayOptions set to false
-    let displayOptions = this.selectedItems[this.selectedItemIndex].toolRuntimeConfig.displayOptions;
+    let displayOptions = this.selectedItems[this.selectedItemIndex]
+      .toolRuntimeConfig.displayOptions;
     Object.keys(displayOptions).forEach(displayOption => {
       if (!displayOptions[displayOption]) {
         delete displayOptions[displayOption];
@@ -122,10 +121,10 @@ export class App {
     });
 
     const message = {
-      action: 'update',
+      action: "update",
       params: this.selectedItems[this.selectedItemIndex]
     };
-    window.parent.postMessage(message, '*');
+    window.parent.postMessage(message, "*");
   }
 
   async reloadItems() {
@@ -133,11 +132,10 @@ export class App {
     try {
       const result = await this.loadItems(this.currentSearchString);
 
-      this.items =  result.items.map(item => {
-        let itemTool = this.tools
-          .filter(tool => {
-            return tool.name === item.getToolName();
-          })[0];
+      this.items = result.items.map(item => {
+        let itemTool = this.tools.filter(tool => {
+          return tool.name === item.getToolName();
+        })[0];
 
         if (itemTool) {
           item.conf.icon = itemTool.icon;
@@ -160,21 +158,28 @@ export class App {
     const numberOfItemsToLoadPerStep = 9;
 
     const availableToolNames = this.tools.map(tool => tool.name);
-    const result = await this.itemStore.getItems(searchString, numberOfItemsToLoadPerStep, availableToolNames, bookmark);
+    const result = await this.itemStore.getItems(
+      searchString,
+      numberOfItemsToLoadPerStep,
+      availableToolNames,
+      bookmark
+    );
     this.itemsLoading = false;
     return result;
   }
 
   async loadMore() {
     try {
-      const result = await this.loadItems(this.currentSearchString, this.bookmark);
+      const result = await this.loadItems(
+        this.currentSearchString,
+        this.bookmark
+      );
 
       this.items = this.items.concat(result.items);
-      this.items =  this.items.map(item => {
-        let itemTool = this.tools
-          .filter(tool => {
-            return tool.name === item.getToolName();
-          })[0];
+      this.items = this.items.map(item => {
+        let itemTool = this.tools.filter(tool => {
+          return tool.name === item.getToolName();
+        })[0];
 
         if (itemTool) {
           item.conf.icon = itemTool.icon;
@@ -197,7 +202,6 @@ export class App {
     return toolResponse.json();
   }
 
-
   updateMoreItemsAvailableState(result) {
     if (result.total_rows > this.items.length) {
       this.moreItemsAvailable = true;
@@ -212,21 +216,27 @@ export class App {
         width: [
           {
             value: this.previewContainer.getBoundingClientRect().width,
-            comparison: '='
+            comparison: "="
           }
         ]
       },
-      displayOptions: this.selectedItems[this.selectedItemIndex].toolRuntimeConfig.displayOptions,
+      displayOptions: this.selectedItems[this.selectedItemIndex]
+        .toolRuntimeConfig.displayOptions,
       isPure: true
     };
 
-    return qEnv.QServerBaseUrl
-      .then(QServerBaseUrl => {
-        if (this.selectedItemIndex !== undefined) {
-          return fetch(`${QServerBaseUrl}/rendering-info/${this.selectedItems[this.selectedItemIndex].id}/${this.target.key}?toolRuntimeConfig=${encodeURI(JSON.stringify(toolRuntimeConfig))}`);
-        }
-        return {};
-      })
+    return qEnv.QServerBaseUrl.then(QServerBaseUrl => {
+      if (this.selectedItemIndex !== undefined) {
+        return fetch(
+          `${QServerBaseUrl}/rendering-info/${
+            this.selectedItems[this.selectedItemIndex].id
+          }/${this.target.key}?toolRuntimeConfig=${encodeURI(
+            JSON.stringify(toolRuntimeConfig)
+          )}`
+        );
+      }
+      return {};
+    })
       .then(res => {
         if (res.ok && res.status >= 200 && res.status < 400) {
           return res.json();
@@ -271,15 +281,16 @@ export class App {
 
   async loadDisplayOptions() {
     try {
-      const item =  await getItem(this.selectedItems[this.selectedItemIndex].id);
+      const item = await getItem(this.selectedItems[this.selectedItemIndex].id);
       this.tool = item.conf.tool;
 
       let selectedItem = this.selectedItems[this.selectedItemIndex];
 
-      qEnv.QServerBaseUrl
-        .then(QServerBaseUrl => {
-          return fetch(`${QServerBaseUrl}/tools/${this.tool}/display-options-schema.json`);
-        })
+      qEnv.QServerBaseUrl.then(QServerBaseUrl => {
+        return fetch(
+          `${QServerBaseUrl}/tools/${this.tool}/display-options-schema.json`
+        );
+      })
         .then(response => {
           if (response.ok) {
             return response.json();
@@ -287,13 +298,15 @@ export class App {
           throw response;
         })
         .then(schema => {
-          if (schema.hasOwnProperty('properties')) {
+          if (schema.hasOwnProperty("properties")) {
             // we just accept one object containing simple boolean type properties
             Object.keys(schema.properties).forEach(propertyName => {
               // maybe delete all non boolean properties here??
               let displayOption = schema.properties[propertyName];
               if (displayOption.title) {
-                schema.properties[propertyName].title = this.i18n.tr(`${this.tool}:${displayOption.title}`);
+                schema.properties[propertyName].title = this.i18n.tr(
+                  `${this.tool}:${displayOption.title}`
+                );
               }
             });
           }
@@ -303,7 +316,9 @@ export class App {
           }
 
           if (!selectedItem.toolRuntimeConfig.displayOptions) {
-            selectedItem.toolRuntimeConfig.displayOptions = this.objectFromSchemaGenerator.generateFromSchema(schema);
+            selectedItem.toolRuntimeConfig.displayOptions = this.objectFromSchemaGenerator.generateFromSchema(
+              schema
+            );
           }
         })
         .catch(err => {
@@ -317,7 +332,7 @@ export class App {
           }
         });
     } catch (e) {
-      throw new Error('no tool defined');
+      throw new Error("no tool defined");
     }
   }
 }

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -203,11 +203,7 @@ export class App {
   }
 
   updateMoreItemsAvailableState(result) {
-    if (result.total_rows >= this.items.length) {
-      this.moreItemsAvailable = true;
-    } else {
-      this.moreItemsAvailable = false;
-    }
+    this.moreItemsAvailable = result.moreItemsAvailable;
   }
 
   fetchRenderingInfo() {

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -121,11 +121,7 @@ export class Index {
   }
 
   updateMoreItemsAvailableState(result) {
-    if (result.total_rows >= this.items.length) {
-      this.moreItemsAvailable = true;
-    } else {
-      this.moreItemsAvailable = false;
-    }
+    this.moreItemsAvailable = result.moreItemsAvailable;
   }
 
   async loadStatistics() {

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -1,20 +1,27 @@
-import { inject, singleton } from 'aurelia-framework';
-import { Router } from 'aurelia-router';
-import { Notification } from 'aurelia-notification';
-import User from 'resources/User.js';
-import ItemStore from 'resources/ItemStore.js';
-import ToolsInfo from 'resources/ToolsInfo.js';
-import Statistics from 'resources/Statistics.js';
-import QConfig from 'resources/QConfig.js';
+import { inject, singleton } from "aurelia-framework";
+import { Router } from "aurelia-router";
+import { Notification } from "aurelia-notification";
+import User from "resources/User.js";
+import ItemStore from "resources/ItemStore.js";
+import ToolsInfo from "resources/ToolsInfo.js";
+import Statistics from "resources/Statistics.js";
+import QConfig from "resources/QConfig.js";
 
 @singleton()
 @inject(ItemStore, User, ToolsInfo, Router, QConfig, Statistics, Notification)
 export class Index {
-
   enoughNewItems = true;
   initialised = false;
 
-  constructor(itemStore, user, toolsInfo, router, qConfig, statistics, notification) {
+  constructor(
+    itemStore,
+    user,
+    toolsInfo,
+    router,
+    qConfig,
+    statistics,
+    notification
+  ) {
     this.itemStore = itemStore;
     this.user = user;
     this.toolsInfo = toolsInfo;
@@ -39,14 +46,13 @@ export class Index {
     this.availableFilters = this.itemStore.getFilters();
 
     // apply stored user filter selections
-    if (this.user.getUserConfig('q-filters')) {
-      for (let userFilterSelection of this.user.getUserConfig('q-filters')) {
-        this.availableFilters
-          .map(filter => {
-            if (filter.name === userFilterSelection.name) {
-              filter.selected = userFilterSelection.selected;
-            }
-          });
+    if (this.user.getUserConfig("q-filters")) {
+      for (let userFilterSelection of this.user.getUserConfig("q-filters")) {
+        this.availableFilters.map(filter => {
+          if (filter.name === userFilterSelection.name) {
+            filter.selected = userFilterSelection.selected;
+          }
+        });
       }
     }
 
@@ -60,8 +66,9 @@ export class Index {
 
     // store current filter selection on user object
     if (this.user) {
-      this.user.setUserConfig('q-filters', this.availableFilters
-        .map(filter => {
+      this.user.setUserConfig(
+        "q-filters",
+        this.availableFilters.map(filter => {
           return {
             name: filter.name,
             selected: filter.selected
@@ -74,16 +81,21 @@ export class Index {
   async loadItems(searchString, bookmark) {
     try {
       this.itemsLoading = true;
-      let itemListConfig = await this.qConfig.get('itemList');
+      let itemListConfig = await this.qConfig.get("itemList");
       let availableToolsNames = await this.toolsInfo.getAvailableToolsNames();
 
       let numberOfItemsToLoadPerStep = itemListConfig.itemsPerLoad || 18;
 
-      const result = await this.itemStore.getItems(searchString, numberOfItemsToLoadPerStep, availableToolsNames, bookmark);
+      const result = await this.itemStore.getItems(
+        searchString,
+        numberOfItemsToLoadPerStep,
+        availableToolsNames,
+        bookmark
+      );
       this.itemsLoading = false;
       return result;
     } catch (e) {
-      this.notification.error('notifications.failedLoadingItems');
+      this.notification.error("notifications.failedLoadingItems");
     }
   }
 
@@ -98,7 +110,10 @@ export class Index {
   }
 
   async loadMore() {
-    const result = await this.loadItems(this.currentSearchString, this.bookmark);
+    const result = await this.loadItems(
+      this.currentSearchString,
+      this.bookmark
+    );
     this.items = this.items.concat(result.items);
     this.bookmark = result.bookmark;
     this.updateMoreItemsAvailableState(result);
@@ -120,10 +135,12 @@ export class Index {
       let statsValues = {};
       statsValues.totalActiveCount = await this.statistics.getNumberOfActiveItems();
 
-      const lowNewItemsConfig = await this.qConfig.get('lowNewItems');
+      const lowNewItemsConfig = await this.qConfig.get("lowNewItems");
       statsValues.days = lowNewItemsConfig.days;
 
-      statsValues.count = await this.statistics.getNumberOfActiveItems(lowNewItemsConfig.days);
+      statsValues.count = await this.statistics.getNumberOfActiveItems(
+        lowNewItemsConfig.days
+      );
 
       // only set the stats after all values are available
       this.statsValues = statsValues;
@@ -137,5 +154,4 @@ export class Index {
       // we do not care about errors here but just do not show statistics if something failed
     }
   }
-
 }

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -121,7 +121,7 @@ export class Index {
   }
 
   updateMoreItemsAvailableState(result) {
-    if (result.total_rows > this.items.length) {
+    if (result.total_rows >= this.items.length) {
       this.moreItemsAvailable = true;
     } else {
       this.moreItemsAvailable = false;

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -134,39 +134,40 @@ export default class ItemStore {
   }
 
   async getSearchUrl(searchString, limit, bookmark) {
-    const QServerBaseUrl = await qEnv.QServerBaseUrl;
-    let searchUrl = `${QServerBaseUrl}/search?`;
+    const searchParams = new URLSearchParams();
     for (let filter of this.filters) {
       if (filter.name === "tool" && filter.selected !== "all") {
-        searchUrl = searchUrl + "tool=" + filter.selected + "&";
+        searchParams.append("tool", filter.selected);
       }
       await this.user.loaded;
       if (filter.name === "createdBy" && filter.selected === "byMe") {
-        searchUrl = searchUrl + "createdBy=" + this.user.data.username + "&";
+        searchParams.append("createdBy", this.user.data.username);
       }
       if (filter.name === "department" && filter.selected === "myDepartment") {
-        searchUrl = searchUrl + "department=" + this.user.data.department + "&";
+        searchParams.append("department", this.user.data.department);
       }
       if (filter.name === "publication" && filter.selected !== "all") {
-        searchUrl = searchUrl + "publication=" + filter.selected + "&";
+        searchParams.append("publication", filter.selected);
       }
       if (filter.name === "active" && filter.selected !== "all") {
-        searchUrl =
-          searchUrl + "active=" + filter.selected === "onlyActive"
-            ? "true"
-            : "false" + "&";
+        if (filter.selected === "onlyActive") {
+          searchParams.append("active", "true");
+        } else {
+          searchParams.append("active", "false");
+        }
       }
     }
     if (searchString) {
-      searchUrl = searchUrl + "searchString=" + searchString + "&";
+      searchParams.append("searchString", searchString);
     }
     if (limit) {
-      searchUrl = searchUrl + "limit=" + limit + "&";
+      searchParams.append("limit", limit);
     }
     if (bookmark) {
-      searchUrl = searchUrl + "bookmark=" + bookmark + "&";
+      searchParams.append("bookmark", bookmark);
     }
-    return searchUrl;
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
+    return `${QServerBaseUrl}/search?${searchParams.toString()}`;
   }
 
   async getItems(

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -133,11 +133,13 @@ export default class ItemStore {
     return this.items[id];
   }
 
-  async getSearchUrl(searchString, limit, bookmark) {
+  async getSearchUrl(searchString, limit, bookmark, onlyTools) {
     const searchParams = new URLSearchParams();
     for (let filter of this.filters) {
       if (filter.name === "tool" && filter.selected !== "all") {
         searchParams.append("tool", filter.selected);
+        // we do have a specific tool filter, so we do not want to have the onlyTools processed
+        onlyTools = undefined;
       }
       await this.user.loaded;
       if (filter.name === "createdBy" && filter.selected === "byMe") {
@@ -156,6 +158,9 @@ export default class ItemStore {
           searchParams.append("active", "false");
         }
       }
+    }
+    if (onlyTools) {
+      searchParams.append("tool", onlyTools);
     }
     if (searchString) {
       searchParams.append("searchString", searchString);
@@ -176,7 +181,12 @@ export default class ItemStore {
     onlyTools = undefined,
     bookmark = undefined
   ) {
-    const searchUrl = await this.getSearchUrl(searchString, limit, bookmark);
+    const searchUrl = await this.getSearchUrl(
+      searchString,
+      limit,
+      bookmark,
+      onlyTools
+    );
     const response = await this.httpClient.fetch(searchUrl, {
       method: "GET"
     });

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -172,7 +172,7 @@ export default class ItemStore {
 
   async getItems(
     searchString = undefined,
-    limit,
+    limit = 18,
     onlyTools = undefined,
     bookmark = undefined
   ) {
@@ -198,7 +198,7 @@ export default class ItemStore {
     });
     return {
       items: items,
-      total_rows: data.docs.length,
+      moreItemsAvailable: data.docs.length === limit,
       bookmark: data.bookmark
     };
   }

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -202,8 +202,6 @@ export default class ItemStore {
     };
   }
 
-  async loadItems(searchRequestBody) {}
-
   getFilters() {
     return this.filters;
   }

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -206,6 +206,9 @@ export default class ItemStore {
       this.items[doc._id];
       return item;
     });
+
+    // moreItemsAvailable: As long as the returned amount of items are the same as the limit there are more items available
+    // See pagination section in http://docs.couchdb.org/en/2.1.1/api/database/find.html
     return {
       items: items,
       moreItemsAvailable: data.docs.length === limit,

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -160,7 +160,7 @@ export default class ItemStore {
       }
     }
     if (onlyTools) {
-      searchParams.append("tool", onlyTools);
+      searchParams.append("tool", JSON.stringify(onlyTools));
     }
     if (searchString) {
       searchParams.append("searchString", searchString);


### PR DESCRIPTION
- This PR moves the search implementation to the q-server
- There is now an endpoint which takes requests in the following form:
```http
GET /search?
tool=imageslider&
createdBy=manuel.roth@nzz.ch&
department=Storytelling%20/%20Infografik&
publication=nzz&
searchString=Bundesrat&
limit=18
```