### PR TITLE
Don't try to translate undefined values

### DIFF
--- a/client/src/value-converters/ToolTValueConverter.js
+++ b/client/src/value-converters/ToolTValueConverter.js
@@ -10,7 +10,9 @@ export class ToolTValueConverter {
   }
 
   toView(value, options) {
-    const item = this.currentItemProvider.getCurrentItem();
-    return this.service.tr(`${item.conf.tool}:${value}`, options);
+    if (value !== undefined) {
+      const item = this.currentItemProvider.getCurrentItem();
+      return this.service.tr(`${item.conf.tool}:${value}`, options);
+    }
   }
 }


### PR DESCRIPTION
- This PR improves the `ToolTValueConverter` so that undefined values are not getting translated
- Currently this can result in undefined being shown in the schema editor:

<img width="1039" alt="bildschirmfoto 2018-07-02 um 17 19 08" src="https://user-images.githubusercontent.com/1810384/42173616-f19c5d82-7e1f-11e8-8fb6-fc206730b724.png">
- This branch is deployed on https://q.st-test.nzz.ch/editor/map
