### PR TITLE
Bind minimum and maximum schema values to input element

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-number.html
+++ b/client/src/elements/schema-editor/schema-editor-number.html
@@ -6,6 +6,6 @@
       <span style="color: var(--q-color-error)">${'editor.required' & t}</span>
     </span>
     <input type="number" placeholder.to-view="options.placeholder || '' & toolT" required.bind="required" value.bind="data | forceNumber"
-      step.bind="options.step" keyup.delegate="change() & debounce:800">
+      step.bind="options.step" min.bind="schema.minimum" max.bind="schema.maximum" keyup.delegate="change() & debounce:800">
     <label>
 </template>


### PR DESCRIPTION
- This PR adds bindings for minimum and maximum values to the `schema-editor-number` component