### PR TITLE
Allow to copy 10000 rows and 100 columns

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -96,7 +96,10 @@ export class SchemaEditorTable {
       contextMenu: false,
       stretchH: "all",
       rowHeights: 23,
-      copyRowsLimit: 10000,
+      copyPaste: {
+        rowsLimit: 10000,
+        columnsLimit: 100
+      },
       afterChange: (changes, source) => {
         if (source !== "loadData") {
           this.data = trimNull(emptyToNull(this.hot.getData()));


### PR DESCRIPTION
- This PR sets the copy limit to 10000 rows and 100 columns
- @benib already tried to fix this (https://github.com/nzzdev/Q-editor/commit/be028ed9924343c3890e8b43c94f3f05b32e0322#diff-bb27bc2e1da8715ed44267c6f807b554), but the `copyRowsLimit` was replaced with `copyPaste` option in some version of handsontable (see github issue discussion [here](https://github.com/handsontable/handsontable/issues/3524)). Unfortunately they haven't updated the documentation yet.
- This branch will be deployed on staging as soon as https://github.com/nzzdev/Q-editor/pull/154 was reviewed
