### PR TITLE
Create sophie link out of sophie modules array

### DIFF
--- a/client/env
+++ b/client/env
@@ -1,5 +1,6 @@
 {
   "QServerBaseUrl": "http://localhost:3001",
+  "SophieBuildService": "https://sophieservicestage-2cac.kxcdn.com/bundle/",
   "loginMessage": "login message",
   "devLogging": true,
   "pushState": false

--- a/client/src/elements/item-preview/item-preview.js
+++ b/client/src/elements/item-preview/item-preview.js
@@ -27,10 +27,14 @@ const defaultSizeOptions = [
 
 @inject(QTargets, QConfig, User, I18N, Element)
 export class ItemPreview {
-  @bindable data;
-  @bindable id;
-  @bindable target;
-  @observable error = false;
+  @bindable
+  data;
+  @bindable
+  id;
+  @bindable
+  target;
+  @observable
+  error = false;
 
   sizeOptions = [];
   errorMessage = "";
@@ -287,6 +291,21 @@ export class ItemPreview {
           this.targetProxy.target.preview.scripts.forEach(script => {
             renderingInfo.scripts.push(script);
           });
+        }
+
+        // add sophieModules for target preview if any
+        if (
+          this.targetProxy.target.preview &&
+          this.targetProxy.target.preview.sophieModules
+        ) {
+          if (!renderingInfo.sophieModules) {
+            renderingInfo.sophieModules = [];
+          }
+          this.targetProxy.target.preview.sophieModules.forEach(
+            sophieModule => {
+              renderingInfo.sophieModules.push(sophieModule);
+            }
+          );
         }
         return renderingInfo;
       });

--- a/client/src/elements/item-preview/item-preview.js
+++ b/client/src/elements/item-preview/item-preview.js
@@ -293,20 +293,6 @@ export class ItemPreview {
           });
         }
 
-        // add sophieModules for target preview if any
-        if (
-          this.targetProxy.target.preview &&
-          this.targetProxy.target.preview.sophieModules
-        ) {
-          if (!renderingInfo.sophieModules) {
-            renderingInfo.sophieModules = [];
-          }
-          this.targetProxy.target.preview.sophieModules.forEach(
-            sophieModule => {
-              renderingInfo.sophieModules.push(sophieModule);
-            }
-          );
-        }
         return renderingInfo;
       });
   }

--- a/client/src/elements/item-preview/preview-container.js
+++ b/client/src/elements/item-preview/preview-container.js
@@ -4,11 +4,16 @@ import qEnv from "resources/qEnv.js";
 @useShadowDOM()
 @inject(Element)
 export class PreviewContainer {
-  @bindable width;
-  @bindable renderingInfo;
-  @bindable loadingStatus;
-  @bindable target;
-  @bindable error;
+  @bindable
+  width;
+  @bindable
+  renderingInfo;
+  @bindable
+  loadingStatus;
+  @bindable
+  target;
+  @bindable
+  error;
 
   insertedElements = [];
   stylesheetRules = [];
@@ -63,6 +68,20 @@ export class PreviewContainer {
     while (this.insertedElements.length > 0) {
       let element = this.insertedElements.pop();
       element.parentNode.removeChild(element);
+    }
+
+    // load sophie modules
+    if (Array.isArray(renderingInfo.sophieModules)) {
+      const SophieBuildService = await qEnv.SophieBuildService;
+      const sophieModulesString = renderingInfo.sophieModules.reduce(
+        (acc, curr) => `${acc},${curr}`
+      );
+      let link = document.createElement("link");
+      link.type = "text/css";
+      link.rel = "stylesheet";
+      link.href = `${SophieBuildService}${sophieModulesString}.css`;
+      this.insertedElements.push(link);
+      this.element.shadowRoot.appendChild(link);
     }
 
     // load the stylesheets

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -266,6 +266,16 @@ export class App {
             renderingInfo.scripts.push(script);
           });
         }
+
+        // add sophieModules for target preview if any
+        if (this.target.preview && this.target.preview.sophieModules) {
+          if (!renderingInfo.sophieModules) {
+            renderingInfo.sophieModules = [];
+          }
+          this.target.preview.sophieModules.forEach(sophieModule => {
+            renderingInfo.sophieModules.push(sophieModule);
+          });
+        }
         return renderingInfo;
       });
   }


### PR DESCRIPTION
- This PR implements constructing a sophie build service link out of the sophie modules array provided in the renderingInfo
- Closes https://github.com/nzzdev/Q-editor/issues/159
- Tested locally, will be deployed in st-test as soon as other PRs are merged 