### PR TITLE
Fix multiple preview loading on size change

### DIFF
--- a/client/src/elements/item-preview/item-preview.js
+++ b/client/src/elements/item-preview/item-preview.js
@@ -55,7 +55,7 @@ export class ItemPreview {
       {},
       {
         set: (target, property, value, receiver) => {
-          // Only update value if is different from previous value
+          // Only update value if it is different from previous value
           if (target[property] !== value) {
             target[property] = value;
             this.target = value;
@@ -71,7 +71,7 @@ export class ItemPreview {
       {},
       {
         set: (target, property, value, receiver) => {
-          // Only update value if is different from previous value
+          // Only update value if it is different from previous value
           if (target[property] !== value) {
             target[property] = value;
             this.handleSizeChange();

--- a/client/src/elements/item-preview/item-preview.js
+++ b/client/src/elements/item-preview/item-preview.js
@@ -304,7 +304,6 @@ export class ItemPreview {
   }
 
   loadPreview() {
-    console.error("load preview");
     // if we have no target, we cannot load the preview
     if (!this.targetProxy.target || !this.targetProxy.target.key) {
       return;

--- a/client/src/elements/item-preview/item-preview.js
+++ b/client/src/elements/item-preview/item-preview.js
@@ -55,9 +55,12 @@ export class ItemPreview {
       {},
       {
         set: (target, property, value, receiver) => {
-          target[property] = value;
-          this.target = value;
-          this.loadPreview();
+          // Only update value if is different from previous value
+          if (target[property] !== value) {
+            target[property] = value;
+            this.target = value;
+            this.loadPreview();
+          }
           return true;
         }
       }
@@ -68,8 +71,11 @@ export class ItemPreview {
       {},
       {
         set: (target, property, value, receiver) => {
-          target[property] = value;
-          this.handleSizeChange();
+          // Only update value if is different from previous value
+          if (target[property] !== value) {
+            target[property] = value;
+            this.handleSizeChange();
+          }
           return true;
         }
       }
@@ -298,6 +304,7 @@ export class ItemPreview {
   }
 
   loadPreview() {
+    console.error("load preview");
     // if we have no target, we cannot load the preview
     if (!this.targetProxy.target || !this.targetProxy.target.key) {
       return;


### PR DESCRIPTION
- This PR fixes a long standing bug with the preview. The preview always loaded twice when changing the preview size. 
- The preview size is set twice on the `previewWidthProxy` when switching between previewWidths ([because of two-way data binding](https://github.com/nzzdev/Q-editor/blob/dev/client/src/elements/item-preview/item-preview.html#L9))
- This PR fixes this by only updating the value if it is different from previous value
- Closes https://github.com/nzzdev/Q-editor/issues/92