### PR TITLE
(editor) append item id to url after first save

### DIFF
--- a/client/src/pages/editor.js
+++ b/client/src/pages/editor.js
@@ -237,6 +237,16 @@ export class Editor {
         // whenever we save the item, we need to reevaluate all the checks
         this.triggerReevaluations();
       })
+      .then(() => {
+        // ensure url includes the item id (it does not before first save for a new item)
+        if (!window.location.href.includes(this.item.id)) {
+          window.history.replaceState(
+            null,
+            "",
+            `${window.location.href}/${this.item.id}`
+          );
+        }
+      })
       .catch(error => {
         if (error.message === "isSaving") {
           // this is fine, we do not show an error in this case


### PR DESCRIPTION
- This is using the History API to append the item id to the url if it's not there yet
- This happens when a new item is saved for the first time as we do not know the id before the first save
- This is implemented as sometimes people send links to their graphic (because they have a question/problem) but the id is not yet part of it as they never left the editor after creating the new graphic

deployed on test env.