### PR TITLE
Fix regenerate ids on blueprint

### DIFF
--- a/client/src/resources/IdGenerator.js
+++ b/client/src/resources/IdGenerator.js
@@ -13,10 +13,18 @@ export default class IdGenerator {
 
   getIdWithCurrentItemId() {
     const item = this.currentItemProvider.getCurrentItem();
+    return this.getIdWithItemId(item);
+  }
+
+  getIdWithItemId(item) {
     if (!item.id) {
       return null;
     }
 
-    return item.id + "-" + this.getId();
+    return this.getIdWithId(item.id);
+  }
+
+  getIdWithId(id) {
+    return id + "-" + this.getId();
   }
 }

--- a/client/src/resources/Item.js
+++ b/client/src/resources/Item.js
@@ -60,22 +60,6 @@ export default class Item {
     this.conf = Object.assign(this.conf, doc);
   }
 
-  async blueprint() {
-    const oldConf = JSON.parse(JSON.stringify(this.conf));
-    this.conf._id = undefined;
-    this.conf._rev = undefined;
-    this.conf.active = false;
-    await this.setDepartmentToUserDepartment();
-    await this.setPublicationToUserPublication();
-    await this.setAcronymToUserAcronym();
-    try {
-      return this.save();
-    } catch (e) {
-      this.conf = oldConf;
-      throw e;
-    }
-  }
-
   addConf(conf) {
     Object.assign(this.conf, conf);
     return this;
@@ -157,5 +141,20 @@ export default class Item {
     }
 
     return true;
+  }
+
+  async getSchema() {
+    if (this.schema) {
+      return this.schema;
+    }
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
+    const response = await this.httpClient.fetch(
+      `${QServerBaseUrl}/tools/${this.getToolName()}/schema.json`
+    );
+    if (response.ok) {
+      this.schema = await response.json();
+      return this.schema;
+    }
+    return null;
   }
 }

--- a/client/src/resources/ItemActionController.js
+++ b/client/src/resources/ItemActionController.js
@@ -5,15 +5,17 @@ import { I18N } from "aurelia-i18n";
 import { DialogService } from "aurelia-dialog";
 import { ConfirmDialog } from "dialogs/confirm-dialog.js";
 import QConfig from "resources/QConfig.js";
+import ItemStore from "resources/ItemStore";
 
-@inject(Router, Notification, I18N, DialogService, QConfig)
+@inject(Router, Notification, I18N, DialogService, QConfig, ItemStore)
 export default class ItemActionController {
-  constructor(router, notification, i18n, dialogService, qConfig) {
+  constructor(router, notification, i18n, dialogService, qConfig, itemStore) {
     this.router = router;
     this.notification = notification;
     this.i18n = i18n;
     this.dialogService = dialogService;
     this.qConfig = qConfig;
+    this.itemStore = itemStore;
   }
 
   activate(item) {
@@ -103,9 +105,10 @@ export default class ItemActionController {
 
   async blueprint(item) {
     try {
-      await item.blueprint();
-      item.conf.title = this.i18n.tr("item.blueprintTitlePrefix");
-      this.router.navigate(`/editor/${item.conf.tool}/${item.conf._id}`);
+      const blueprintedItem = await this.itemStore.getBlueprintedItem(item.id);
+      this.router.navigate(
+        `/editor/${blueprintedItem.getToolName()}/${blueprintedItem.id}`
+      );
     } catch (e) {
       this.notification.error("notification.failedToLoadItem");
     }

--- a/client/src/resources/ItemStore.js
+++ b/client/src/resources/ItemStore.js
@@ -1,22 +1,42 @@
 import { inject } from "aurelia-framework";
 import { BindingEngine } from "aurelia-binding";
 import { HttpClient } from "aurelia-fetch-client";
+import { I18N } from "aurelia-i18n";
 import qEnv from "resources/qEnv.js";
 import User from "resources/User.js";
 import Item from "resources/Item.js";
 import ToolsInfo from "resources/ToolsInfo.js";
 import QConfig from "resources/QConfig.js";
+import ObjectFromSchemaGenerator from "resources/ObjectFromSchemaGenerator";
 
-@inject(User, ToolsInfo, QConfig, BindingEngine, HttpClient)
+@inject(
+  User,
+  ToolsInfo,
+  QConfig,
+  ObjectFromSchemaGenerator,
+  BindingEngine,
+  HttpClient,
+  I18N
+)
 export default class ItemStore {
   items = {};
 
-  constructor(user, toolsInfo, qConfig, bindingEngine, httpClient) {
+  constructor(
+    user,
+    toolsInfo,
+    qConfig,
+    objectFromSchemaGenerator,
+    bindingEngine,
+    httpClient,
+    i18n
+  ) {
     this.user = user;
     this.toolsInfo = toolsInfo;
     this.qConfig = qConfig;
+    this.objectFromSchemaGenerator = objectFromSchemaGenerator;
     this.bindingEngine = bindingEngine;
     this.httpClient = httpClient;
+    this.i18n = i18n;
 
     this.initFilters();
   }
@@ -134,6 +154,44 @@ export default class ItemStore {
     }
     await this.items[id].load(id);
     return this.items[id];
+  }
+
+  async getBlueprintedItem(id) {
+    // get the original
+    const item = await this.getItem(id);
+
+    // create a new one to hold the blueprinted data
+    const blueprintedItem = this.getNewItem();
+
+    // set the tool, we need to know what schema to load blueprint
+    blueprintedItem.conf.tool = item.conf.tool;
+
+    // set the title, otherwise we cannot save it
+    blueprintedItem.conf.title = `${this.i18n.tr(
+      "item.blueprintTitlePrefix"
+    )} ${item.conf.title}`;
+
+    // save to get a new id
+    await blueprintedItem.save();
+
+    // generate the new conf based on the original item and the schema
+    const blueprintedItemConf = this.objectFromSchemaGenerator.generateFromItemAndSchema(
+      item.conf,
+      await item.getSchema(),
+      blueprintedItem.id
+    );
+
+    // remove the title from the new conf, this is a little hacky, but we set the title already before to be able to save
+    delete blueprintedItemConf.title;
+
+    // add the blueprinted conf to the new item
+    blueprintedItem.addConf(blueprintedItemConf);
+
+    // save again
+    await blueprintedItem.save();
+
+    this.items[blueprintedItem.id] = blueprintedItem;
+    return this.items[blueprintedItem.id];
   }
 
   async getSearchUrl(searchString, limit, bookmark, onlyTools) {

--- a/client/src/resources/ObjectFromSchemaGenerator.js
+++ b/client/src/resources/ObjectFromSchemaGenerator.js
@@ -1,4 +1,5 @@
-import { inject } from "aurelia-framework";
+import { inject, LogManager } from "aurelia-framework";
+const log = LogManager.getLogger("Q");
 import IdGenerator from "./IdGenerator.js";
 import Ajv from "ajv";
 const ajv = new Ajv();
@@ -85,7 +86,7 @@ export default class ObjectFromSchemaGenerator {
       if (itemPart === undefined) {
         return undefined;
       }
-      console.error(e);
+      log.error(e);
       return undefined;
     }
     // if the current itemPart is an object, we remove the properties that are not defined in the schema
@@ -164,10 +165,10 @@ export default class ObjectFromSchemaGenerator {
     }
     const possibleSchemas = this.getPossibleItemSchemas(schema);
     if (possibleSchemas) {
-      for (const schema of possibleSchemas) {
-        const validate = ajv.compile(schema);
+      for (const possibleSchema of possibleSchemas) {
+        const validate = ajv.compile(possibleSchema);
         if (validate(data)) {
-          return schema;
+          return possibleSchema;
         }
       }
       return null;

--- a/client/src/resources/ObjectFromSchemaGenerator.js
+++ b/client/src/resources/ObjectFromSchemaGenerator.js
@@ -39,11 +39,9 @@ export default class ObjectFromSchemaGenerator {
           }
         }
       }
-      if (schema.default !== undefined) {
-        const defaultValue = this.getDefaultOrNull(schema);
-        if (defaultValue) {
-          array = defaultValue;
-        }
+      const defaultValue = this.getDefaultOrNull(schema);
+      if (defaultValue !== null) {
+        array = defaultValue;
       }
       return array;
     } else if (schema.type === "object") {

--- a/client/src/resources/ObjectFromSchemaGenerator.js
+++ b/client/src/resources/ObjectFromSchemaGenerator.js
@@ -1,5 +1,7 @@
 import { inject } from "aurelia-framework";
 import IdGenerator from "./IdGenerator.js";
+import Ajv from "ajv";
+const ajv = new Ajv();
 
 @inject(IdGenerator)
 export default class ObjectFromSchemaGenerator {
@@ -71,5 +73,116 @@ export default class ObjectFromSchemaGenerator {
       return defaultValue;
     }
     return undefined;
+  }
+
+  // TODO: Do not apply all the values from existing item to the new one but use the schema do define what should be added.
+  // everything else meta things and id and all that will come from somewhere else.
+  generateFromItemAndSchema(itemPart, schema, idForIdGenerator) {
+    // clone to not overwrite original
+    try {
+      itemPart = JSON.parse(JSON.stringify(itemPart));
+    } catch (e) {
+      if (itemPart === undefined) {
+        return undefined;
+      }
+      console.error(e);
+      return undefined;
+    }
+    // if the current itemPart is an object, we remove the properties that are not defined in the schema
+    // this is especially to get rid of any metaproperties that will be added outside of the scope of this function.
+    if (schema.type === "object") {
+      Object.keys(itemPart).forEach(propertyName => {
+        if (!schema.properties.hasOwnProperty(propertyName)) {
+          delete itemPart[propertyName];
+        }
+      });
+    }
+
+    if (schema.type === "array") {
+      // add new elements to the array if we do not meet minItems
+      const newArrayItems = [];
+      if (schema.minItems !== undefined) {
+        if (itemPart.length < schema.minItems) {
+          const numberOfArrayItemsToAdd = schema.minItems - itemPart.length;
+          for (let i = 0; i < numberOfArrayItemsToAdd; i++) {
+            const defaultValue = this.getDefaultOrNull(schema);
+            if (defaultValue !== null) {
+              newArrayItems.push(defaultValue);
+            }
+          }
+        }
+      }
+      // loop over all existing array items to handle them and concat with any new ones generated above
+      return itemPart
+        .map(arrayItem => {
+          const arrayItemSchema = this.getArrayItemSchemaForData(
+            arrayItem,
+            schema
+          );
+          return this.generateFromItemAndSchema(
+            arrayItem,
+            arrayItemSchema,
+            idForIdGenerator
+          );
+        })
+        .concat(newArrayItems);
+    } else if (schema.type === "object") {
+      if (!schema.hasOwnProperty("properties")) {
+        return undefined;
+      }
+      Object.keys(schema.properties).forEach(propertyName => {
+        let value = this.generateFromItemAndSchema(
+          itemPart[propertyName],
+          schema.properties[propertyName],
+          idForIdGenerator
+        );
+        if (value !== undefined) {
+          itemPart[propertyName] = value;
+        }
+      });
+      return itemPart;
+    }
+    // if this itemPart is a generatedId, we regenerate the id
+    if (schema.hasOwnProperty("Q:default")) {
+      if (schema["Q:default"] === "generatedId") {
+        const id = this.idGenerator.getIdWithId(idForIdGenerator);
+        if (id === undefined || id === null) {
+          throw new Error(
+            "failed to generate id with item id as item has no id yet"
+          );
+        }
+        return id;
+      }
+    }
+    // in all other cases, we return the existing value
+    return itemPart;
+  }
+
+  getArrayItemSchemaForData(data, schema) {
+    if (schema.items.type) {
+      return schema.items;
+    }
+    const possibleSchemas = this.getPossibleItemSchemas(schema);
+    if (possibleSchemas) {
+      for (const schema of possibleSchemas) {
+        const validate = ajv.compile(schema);
+        if (validate(data)) {
+          return schema;
+        }
+      }
+      return null;
+    }
+  }
+
+  getPossibleItemSchemas(schema) {
+    let possibleSchemas;
+    if (schema.items.oneOf) {
+      possibleSchemas = schema.items.oneOf;
+    } else if (schema.items.anyOf) {
+      possibleSchemas = schema.items.anyOf;
+    } else if (schema.items.allOf) {
+      possibleSchemas = schema.items.allOf;
+    }
+    return possibleSchemas;
   }
 }

--- a/client/src/resources/ObjectFromSchemaGenerator.js
+++ b/client/src/resources/ObjectFromSchemaGenerator.js
@@ -35,7 +35,7 @@ export default class ObjectFromSchemaGenerator {
         for (let i = 0; i < schema.minItems; i++) {
           let value = this.generateFromSchema(schema.items);
           if (value) {
-            array.push();
+            array.push(value);
           }
         }
       }


### PR DESCRIPTION
- fixes #62 
- this refactors the blueprinting like this:
  - do not just copy the data and changing some properties
  - instead generate a new object based on the tools schema
  - all properties that are available on the original object but not defined in the schema will be removed
  - any property that has `generatedId` as the `Q:default` will be regenerated based on the new id

This can be tested with our quiz tool (the id of the single questions needs to be regenerated on blueprinting based on the new id).