### PR TITLE
Make action buttons in ld preview more compact

### DIFF
--- a/client/src/livingdocs-component-app/app.css
+++ b/client/src/livingdocs-component-app/app.css
@@ -229,19 +229,5 @@ html {
   border-top: 1px solid var(--q-color-gray-4);
   display: flex;
   justify-content: space-around;
-}
-
-.livingdocs-component-item-controls > div {
-  text-align: center;
-}
-
-.livingdocs-component-item-controls > div button-secondary,
-.livingdocs-component-item-controls > div button-primary,
-.livingdocs-component-item-controls > div span {
-  margin: 0 auto;
-}
-
-.livingdocs-component-item-controls button-primary,
-.livingdocs-component-item-controls button-secondary {
-  width: 48px;
+  min-height: 45px;
 }

--- a/client/src/livingdocs-component-app/app.html
+++ b/client/src/livingdocs-component-app/app.html
@@ -82,13 +82,11 @@
         <div class="livingdocs-component-item-controls">
           <div class="item-edit">
             <a href="#/editor/${tool}/${selectedItems[selectedItemIndex].id}" target="_blank">
-              <button-secondary size="big" icon="edit"></button-secondary>
+              <button-secondary icon="edit">${'livingdocsComponent.edit' & t}</button-secondary>
             </a>
-            <span class="q-text">${'livingdocsComponent.edit' & t}</span>
           </div>
           <div class="item-insert">
-            <button-primary click.delegate="insertItem()" size="big" icon="deactivate"></button-primary>
-            <span class="q-text">${'livingdocsComponent.insert' & t}</span>
+            <button-primary click.delegate="insertItem()" icon="deactivate">${'livingdocsComponent.insert' & t}</button-primary>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- This PR makes the action buttons in ld preview more compact (so there is more space available for the displayOptions)

![bildschirmfoto 2018-10-03 um 15 30 20](https://user-images.githubusercontent.com/1810384/46413464-43320580-c721-11e8-8af8-4e2d84b35df6.png)
