### PR TITLE
(schema-editor-table) trim whitespace only cells

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -48,7 +48,7 @@ function trimNull(data) {
 
 function emptyToNull(data) {
   array2d.eachCell(data, (cell, i, j) => {
-    if (cell === "" || cell === undefined) {
+    if (cell === "" || cell === undefined || cell.trim() === "") {
       data[i][j] = null;
     }
   });


### PR DESCRIPTION
- implements https://github.com/nzzdev/Q-editor/issues/173
- we do not trim all cells values (this could be a reasonable feature as well) but only trim to test if it contains only whitespace and set the cells value to `null` in this case. `null` values then get trimmed from the matrix (removed only if outside the part containing data) when the data changes.