### PR TITLE
Release 3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+# 3.5.3 (23.10.2018)
+- fix: trim all cells in schema-editor-table when data is pasted or edited by hand
+
 # 3.5.2 (19.10.2018)
 - fix: blueprinting of items with arrays of objects with types using implicit properties (`files`) works now.
 

--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -48,7 +48,7 @@ function trimNull(data) {
 
 function emptyToNull(data) {
   array2d.eachCell(data, (cell, i, j) => {
-    if (cell === "" || cell === undefined) {
+    if (cell === "" || cell === undefined || cell.trim() === "") {
       data[i][j] = null;
     }
   });

--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -46,9 +46,18 @@ function trimNull(data) {
   );
 }
 
+function trimAllStrings(data) {
+  array2d.eachCell(data, (cell, i, j) => {
+    if (typeof data[i][j] === "string") {
+      data[i][j] = cell.trim();
+    }
+  });
+  return data;
+}
+
 function emptyToNull(data) {
   array2d.eachCell(data, (cell, i, j) => {
-    if (cell === "" || cell === undefined || cell.trim() === "") {
+    if (cell === "" || cell === undefined) {
       data[i][j] = null;
     }
   });
@@ -232,7 +241,9 @@ export class SchemaEditorTable {
       },
       afterChange: (changes, source) => {
         if (source !== "loadData") {
-          this.setData(trimNull(emptyToNull(this.hot.getData())));
+          this.setData(
+            trimNull(emptyToNull(trimAllStrings(this.hot.getData())))
+          );
           this.change();
         }
         if (this.hot) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
- trim whitespace from all cells in schema-editor-table

this is deployed on stage