### PR TITLE
Checks if file has type before checking if its an image

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-files.js
+++ b/client/src/elements/schema-editor/schema-editor-files.js
@@ -188,7 +188,7 @@ export class SchemaEditorFiles {
 
         this.dropzone.files.push(mockFile);
         this.dropzone.emit("addedfile", mockFile);
-        if (file.type.includes("image/")) {
+        if (file.type && file.type.includes("image/")) {
           mockFile.dataURL = file.url; // needed for dropzone to create the thumbnail in a canvas
           this.dropzone.createThumbnailFromUrl(
             mockFile,


### PR DESCRIPTION
- Images which where uploaded before we added the type property don't properly show a thumbnail at the moment:

![bildschirmfoto 2018-10-30 um 15 42 15](https://user-images.githubusercontent.com/1810384/47726258-684f6080-dc5a-11e8-9c1d-1dc784bdb9b4.png)

- This PR adds a check if the type property is available and falls back to a gray thumbnail if the type is not set:

![bildschirmfoto 2018-10-30 um 15 53 40](https://user-images.githubusercontent.com/1810384/47727066-0859b980-dc5c-11e8-87a4-13b2a1b1d25e.png)
