### PR TITLE
Convert promise chains to async/await in ld component

### DIFF
--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -10,8 +10,7 @@ let loadedItems = [];
 
 async function getItem(id) {
   if (!loadedItems.hasOwnProperty(id)) {
-    const QServerBaseUrl = await qEnv.QServerBaseUrl;
-    const response = await fetch(`${QServerBaseUrl}/item/${id}`);
+    const response = await fetch(`${this.QServerBaseUrl}/item/${id}`);
 
     if (!response.ok) {
       throw response;
@@ -57,6 +56,7 @@ export class App {
   }
 
   async activate() {
+    this.QServerBaseUrl = await qEnv.QServerBaseUrl;
     this.selectedItems = [];
 
     const paramsQuery = /params=(.*)&?/.exec(window.location.search);
@@ -220,8 +220,7 @@ export class App {
   }
 
   async getTools() {
-    const QServerBaseUrl = await qEnv.QServerBaseUrl;
-    const toolResponse = await fetch(`${QServerBaseUrl}/editor/tools`);
+    const toolResponse = await fetch(`${this.QServerBaseUrl}/editor/tools`);
     return toolResponse.json();
   }
 
@@ -244,11 +243,10 @@ export class App {
       isPure: true
     };
 
-    const QServerBaseUrl = await qEnv.QServerBaseUrl;
     let renderingInfo = {};
     if (this.selectedItemIndex !== undefined) {
       const response = await fetch(
-        `${QServerBaseUrl}/rendering-info/${
+        `${this.QServerBaseUrl}/rendering-info/${
           this.selectedItems[this.selectedItemIndex].id
         }/${this.target.key}?toolRuntimeConfig=${encodeURI(
           JSON.stringify(toolRuntimeConfig)
@@ -306,10 +304,9 @@ export class App {
       this.tool = item.conf.tool;
 
       let selectedItem = this.selectedItems[this.selectedItemIndex];
-      const QServerBaseUrl = await qEnv.QServerBaseUrl;
       let displayOptionsSchema = {};
       const response = await fetch(
-        `${QServerBaseUrl}/tools/${this.tool}/display-options-schema.json`
+        `${this.QServerBaseUrl}/tools/${this.tool}/display-options-schema.json`
       );
       if (response.ok) {
         displayOptionsSchema = await response.json();

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -328,7 +328,7 @@ export class App {
       }
     } catch (error) {
       this.displayOptionsSchema = {};
-      selectedItem.toolRuntimeConfig = {
+      this.selectedItems[this.selectedItemIndex].toolRuntimeConfig = {
         displayOptions: {}
       };
     }

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -217,8 +217,8 @@ export class App {
   }
 
   async getTools() {
-    const toolResponse = await fetch(`${this.QServerBaseUrl}/editor/tools`);
-    return toolResponse.json();
+    const response = await fetch(`${this.QServerBaseUrl}/editor/tools`);
+    return await response.json();
   }
 
   async fetchRenderingInfo() {


### PR DESCRIPTION
- This PR replaces promise chaining syntax with async/await in livingdocs component
- Loads the QServerBaseUrl only once and sets it as class attribute
- Makes `getItem` a function of the App class
- There will be more PR's refactoring the ld-component step by step
- This branch is deployed on [st-test](https://q.st-test.nzz.ch/livingdocs-component.html)