### PR TITLE
Appends item to request if tool supports dynamic displayOptions

### DIFF
--- a/client/src/livingdocs-component-app/app.html
+++ b/client/src/livingdocs-component-app/app.html
@@ -23,7 +23,7 @@
         <div class="item-list-entry ${item.conf._id === selectedItem.id ? 'selected' : ''}" click.delegate="selectItem(item)"
           repeat.for="item of items">
           <div class="item-list-entry-title">
-            <box-icon if.bind="item.conf.icon" code.bind="item.conf.icon" size="big" class="tool-icon"></box-icon>
+            <box-icon if.bind="item.toolConfig.icon" code.bind="item.toolConfig.icon" size="big" class="tool-icon"></box-icon>
             <span class="q-text">${item.conf.title}</span>
           </div>
           <div class="item-list-entry-info">

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -131,6 +131,7 @@ export class App {
 
       if (tool) {
         item.conf.icon = tool.icon;
+        item.conf.hasDynamicDisplayOptions = tool.hasDynamicDisplayOptions;
       }
 
       return item;
@@ -185,10 +186,17 @@ export class App {
   async getDisplayOptionsSchema() {
     try {
       let displayOptionsSchema = {};
+      let queryString = "";
+
+      // if the tool supports dynamic displayOptions the item should be appended to the request
+      // in order for the tool to extract the displayOptionsSchema from the item
+      if (this.selectedItem.conf.hasDynamicDisplayOptions) {
+        queryString = `?appendItemToPayload=${this.selectedItem.id}`;
+      }
       const response = await fetch(
         `${this.QServerBaseUrl}/tools/${
-          this.selectedItem.conf.tool
-        }/display-options-schema.json`
+        this.selectedItem.conf.tool
+        }/display-options-schema.json${queryString}`
       );
       if (response.ok) {
         displayOptionsSchema = await response.json();
@@ -242,7 +250,7 @@ export class App {
       let renderingInfo = {};
       const response = await fetch(
         `${this.QServerBaseUrl}/rendering-info/${this.selectedItem.id}/${
-          this.target.key
+        this.target.key
         }?toolRuntimeConfig=${encodeURI(JSON.stringify(toolRuntimeConfig))}`
       );
       if (response.ok) {

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -195,7 +195,7 @@ export class App {
       }
       const response = await fetch(
         `${this.QServerBaseUrl}/tools/${
-        this.selectedItem.conf.tool
+          this.selectedItem.conf.tool
         }/display-options-schema.json${queryString}`
       );
       if (response.ok) {
@@ -250,7 +250,7 @@ export class App {
       let renderingInfo = {};
       const response = await fetch(
         `${this.QServerBaseUrl}/rendering-info/${this.selectedItem.id}/${
-        this.target.key
+          this.target.key
         }?toolRuntimeConfig=${encodeURI(JSON.stringify(toolRuntimeConfig))}`
       );
       if (response.ok) {

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -130,8 +130,10 @@ export class App {
       });
 
       if (tool) {
-        item.conf.icon = tool.icon;
-        item.conf.hasDynamicDisplayOptions = tool.hasDynamicDisplayOptions;
+        item.toolConfig = {
+          icon: tool.icon,
+          hasDynamicDisplayOptions: tool.hasDynamicDisplayOptions
+        };
       }
 
       return item;
@@ -146,6 +148,7 @@ export class App {
     this.selectedItem = {
       id: item.conf._id,
       conf: item.conf,
+      toolConfig: item.toolConfig,
       toolRuntimeConfig: {}
     };
     if (this.selectedItem.conf.active) {
@@ -161,8 +164,9 @@ export class App {
         delete displayOptions[displayOption];
       }
     });
-    // delete the conf property of the selectedItem before saving it with the item
+    // delete the conf and toolConfig properties of the selectedItem before saving it with the item
     delete this.selectedItem.conf;
+    delete this.selectedItem.toolConfig;
     const message = {
       action: "update",
       params: this.selectedItem
@@ -190,7 +194,7 @@ export class App {
 
       // if the tool supports dynamic displayOptions the item should be appended to the request
       // in order for the tool to extract the displayOptionsSchema from the item
-      if (this.selectedItem.conf.hasDynamicDisplayOptions) {
+      if (this.selectedItem.toolConfig.hasDynamicDisplayOptions) {
         queryString = `?appendItemToPayload=${this.selectedItem.id}`;
       }
       const response = await fetch(


### PR DESCRIPTION
- This PR adds the `appendItemToPayload` query string to the displayOptionsSchema request, if the tool sets the property `hasDynamicDisplayOptions`
- This branch is deployed on st-test. This can be tested by updating the displayOptionsSchema of [this item](https://q.st-test.nzz.ch/item/cd11d746cd1d1b6018d83e00b75db4ab) and checking the change [here](https://q.st-test.nzz.ch/livingdocs-component.html)