### PR TITLE
Feat schema editor code

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -39,6 +39,7 @@ System.config({
     "aurelia-testing": "npm:aurelia-testing@1.0.0-beta.4.0.0",
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
+    "codemirror": "npm:codemirror@5.41.0",
     "core-js": "npm:core-js@1.2.7",
     "css": "github:systemjs/plugin-css@0.1.37",
     "dropzone": "npm:dropzone@5.5.1",
@@ -56,7 +57,7 @@ System.config({
       "assert": "npm:assert@1.4.1"
     },
     "github:jspm/nodelibs-buffer@0.1.1": {
-      "buffer": "npm:buffer@5.2.0"
+      "buffer": "npm:buffer@5.2.1"
     },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
@@ -280,9 +281,13 @@ System.config({
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:buffer@5.2.0": {
+    "npm:buffer@5.2.1": {
       "base64-js": "npm:base64-js@1.3.0",
       "ieee754": "npm:ieee754@1.1.12"
+    },
+    "npm:codemirror@5.41.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@1.2.7": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -69,6 +69,7 @@
       "aurelia-templating-resources": "npm:aurelia-templating-resources@^1.6.0",
       "aurelia-templating-router": "npm:aurelia-templating-router@^1.3.1",
       "aurelia-testing": "npm:aurelia-testing@^1.0.0-beta.4.0.0",
+      "codemirror": "npm:codemirror@^5.41.0",
       "css": "github:systemjs/plugin-css@^0.1.32",
       "dropzone": "npm:dropzone@^5.5.1",
       "get-value": "npm:get-value@^3.0.1",

--- a/client/src/elements/schema-editor/schema-editor-code.html
+++ b/client/src/elements/schema-editor/schema-editor-code.html
@@ -1,0 +1,10 @@
+<template class="schema-editor-input ${showNotifications ? 'schema-editor-input--with-notifications' : ''}">
+  <label>
+    ${schema["title"] & toolT}
+    <span show.bind="required">
+      <span>- </span>
+      <span style="color: var(--q-color-error)">${'editor.required' & t}</span>
+    </span>
+    <textarea ref="textareaElement" value.bind="data" placeholder.to-view="options.placeholder || '' & toolT" required.bind="required"></textarea>
+  </label>
+</template>

--- a/client/src/elements/schema-editor/schema-editor-code.js
+++ b/client/src/elements/schema-editor/schema-editor-code.js
@@ -42,20 +42,16 @@ export class SchemaEditorCode {
     if (!window.CodeMirror) {
       try {
         window.CodeMirror = await this.loader.loadModule("codemirror");
-        await this.loader.loadModule(
-          "npm:codemirror@5.41.0/lib/codemirror.css!"
-        );
-        await this.loader.loadModule(
-          "npm:codemirror@5.41.0/mode/javascript/javascript.js"
-        );
-        this.codeMirror = window.CodeMirror.fromTextArea(this.textareaElement, {
-          mode: this.options.mimeType,
-          lineNumbers: true
-        });
-        this.codeMirror.on("change", (codeMirror, change) => {
-          this.data = this.codeMirror.getValue();
-          this.change();
-        });
+        await Promise.all([
+          this.loader.loadModule("npm:codemirror@5.41.0/lib/codemirror.css!"),
+          this.loader.loadModule(
+            "npm:codemirror@5.41.0/mode/javascript/javascript.js"
+          ),
+          this.loader.loadModule(
+            "npm:codemirror@5.41.0/mode/htmlmixed/htmlmixed.js"
+          ),
+          this.loader.loadModule("npm:codemirror@5.41.0/mode/jinja2/jinja2.js")
+        ]);
       } catch (e) {
         log.error(e);
       }
@@ -65,5 +61,16 @@ export class SchemaEditorCode {
       this.showLoadingError = true;
       return;
     }
+
+    this.codeMirror = window.CodeMirror.fromTextArea(this.textareaElement, {
+      mode: this.options.mode || this.options.mimeType,
+      lineNumbers: true,
+      tabSize: 2,
+      lineWrapping: true
+    });
+    this.codeMirror.on("change", (codeMirror, change) => {
+      this.data = this.codeMirror.getValue();
+      this.change();
+    });
   }
 }

--- a/client/src/elements/schema-editor/schema-editor-code.js
+++ b/client/src/elements/schema-editor/schema-editor-code.js
@@ -1,0 +1,69 @@
+import { bindable, inject, Loader, LogManager } from "aurelia-framework";
+import QConfig from "resources/QConfig";
+import { isRequired } from "./helpers.js";
+
+const log = LogManager.getLogger("Q");
+
+@inject(QConfig, Loader)
+export class SchemaEditorCode {
+  @bindable
+  schema;
+  @bindable
+  data;
+  @bindable
+  change;
+  @bindable
+  showNotifications;
+
+  options = {};
+
+  constructor(qConfig, loader) {
+    this.qConfig = qConfig;
+    this.loader = loader;
+    this.isRequired = isRequired;
+  }
+
+  async schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (!this.schema) {
+      return;
+    }
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
+  }
+
+  async attached() {
+    this.showLoadingError = false;
+
+    if (!window.CodeMirror) {
+      try {
+        window.CodeMirror = await this.loader.loadModule("codemirror");
+        await this.loader.loadModule(
+          "npm:codemirror@5.41.0/lib/codemirror.css!"
+        );
+        await this.loader.loadModule(
+          "npm:codemirror@5.41.0/mode/javascript/javascript.js"
+        );
+        this.codeMirror = window.CodeMirror.fromTextArea(this.textareaElement, {
+          mode: this.options.mimeType,
+          lineNumbers: true
+        });
+        this.codeMirror.on("change", (codeMirror, change) => {
+          this.data = this.codeMirror.getValue();
+          this.change();
+        });
+      } catch (e) {
+        log.error(e);
+      }
+    }
+    if (!window.CodeMirror) {
+      log.error("window.Codemirror is not defined after loading codemirror");
+      this.showLoadingError = true;
+      return;
+    }
+  }
+}

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -46,6 +46,17 @@
     ></schema-editor-boolean>
   </div>
 
+  <div if.bind="getType(schema) === 'code'" class="schema-editor-block">
+    <require from="./schema-editor-code"></require>
+    <schema-editor-code
+      schema.bind="schema"
+      data.two-way="data"
+      change.bind="change"
+      required.bind="required"
+      show-notifications.bind="showNotifications"
+    ></schema-editor-code>
+  </div>
+
   <div if.bind="getType(schema) === 'url'" class="schema-editor-block">
     <require from="./schema-editor-url"></require>
     <schema-editor-url


### PR DESCRIPTION
- This implements a new `schema-editor-code` component
- Currently this uses codemirror, but could be changed to something else if we want
- Codemirror is lazy loaded when a schema-editor-code is attached to not bloat the bundle
- We only load html, javascript and jinja2 modes at the moment. This could be made configurable in the future if we see the need.
- The mode for codemirror is set by option `mode` or `mimeType` from the options in the tool schema

See https://github.com/nzzdev/Q-custom-code/pull/33 for an example how this is configured.