### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 3.7.0 (21.11.2018)
+- feature: new schema-editor-code (`"Q:type": "code"`) using codemirror to show a code editor, currently supports javascript and html mime types.
+- feature: `appendItemToPayload` is used appended to the request for `display-options-schema.json` in livingdocs-component if tool config sets `hasDynamicDisplayOptions` to true.
+
 # 3.6.1 (19.11.2018)
 - fix: fix inserting graphics from tools without displayOptions with livingdocs-component
 

--- a/client/config.js
+++ b/client/config.js
@@ -39,6 +39,7 @@ System.config({
     "aurelia-testing": "npm:aurelia-testing@1.0.0-beta.4.0.0",
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
+    "codemirror": "npm:codemirror@5.41.0",
     "core-js": "npm:core-js@1.2.7",
     "css": "github:systemjs/plugin-css@0.1.37",
     "dropzone": "npm:dropzone@5.5.1",
@@ -56,7 +57,7 @@ System.config({
       "assert": "npm:assert@1.4.1"
     },
     "github:jspm/nodelibs-buffer@0.1.1": {
-      "buffer": "npm:buffer@5.2.0"
+      "buffer": "npm:buffer@5.2.1"
     },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
@@ -280,9 +281,13 @@ System.config({
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:buffer@5.2.0": {
+    "npm:buffer@5.2.1": {
       "base64-js": "npm:base64-js@1.3.0",
       "ieee754": "npm:ieee754@1.1.12"
+    },
+    "npm:codemirror@5.41.0": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@1.2.7": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -69,6 +69,7 @@
       "aurelia-templating-resources": "npm:aurelia-templating-resources@^1.6.0",
       "aurelia-templating-router": "npm:aurelia-templating-router@^1.3.1",
       "aurelia-testing": "npm:aurelia-testing@^1.0.0-beta.4.0.0",
+      "codemirror": "npm:codemirror@^5.41.0",
       "css": "github:systemjs/plugin-css@^0.1.32",
       "dropzone": "npm:dropzone@^5.5.1",
       "get-value": "npm:get-value@^3.0.1",

--- a/client/src/elements/schema-editor/schema-editor-code.html
+++ b/client/src/elements/schema-editor/schema-editor-code.html
@@ -1,0 +1,10 @@
+<template class="schema-editor-input ${showNotifications ? 'schema-editor-input--with-notifications' : ''}">
+  <label>
+    ${schema["title"] & toolT}
+    <span show.bind="required">
+      <span>- </span>
+      <span style="color: var(--q-color-error)">${'editor.required' & t}</span>
+    </span>
+    <textarea ref="textareaElement" value.bind="data" placeholder.to-view="options.placeholder || '' & toolT" required.bind="required"></textarea>
+  </label>
+</template>

--- a/client/src/elements/schema-editor/schema-editor-code.js
+++ b/client/src/elements/schema-editor/schema-editor-code.js
@@ -1,0 +1,76 @@
+import { bindable, inject, Loader, LogManager } from "aurelia-framework";
+import QConfig from "resources/QConfig";
+import { isRequired } from "./helpers.js";
+
+const log = LogManager.getLogger("Q");
+
+@inject(QConfig, Loader)
+export class SchemaEditorCode {
+  @bindable
+  schema;
+  @bindable
+  data;
+  @bindable
+  change;
+  @bindable
+  showNotifications;
+
+  options = {};
+
+  constructor(qConfig, loader) {
+    this.qConfig = qConfig;
+    this.loader = loader;
+    this.isRequired = isRequired;
+  }
+
+  async schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (!this.schema) {
+      return;
+    }
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
+  }
+
+  async attached() {
+    this.showLoadingError = false;
+
+    if (!window.CodeMirror) {
+      try {
+        window.CodeMirror = await this.loader.loadModule("codemirror");
+        await Promise.all([
+          this.loader.loadModule("npm:codemirror@5.41.0/lib/codemirror.css!"),
+          this.loader.loadModule(
+            "npm:codemirror@5.41.0/mode/javascript/javascript.js"
+          ),
+          this.loader.loadModule(
+            "npm:codemirror@5.41.0/mode/htmlmixed/htmlmixed.js"
+          ),
+          this.loader.loadModule("npm:codemirror@5.41.0/mode/jinja2/jinja2.js")
+        ]);
+      } catch (e) {
+        log.error(e);
+      }
+    }
+    if (!window.CodeMirror) {
+      log.error("window.Codemirror is not defined after loading codemirror");
+      this.showLoadingError = true;
+      return;
+    }
+
+    this.codeMirror = window.CodeMirror.fromTextArea(this.textareaElement, {
+      mode: this.options.mode || this.options.mimeType,
+      lineNumbers: true,
+      tabSize: 2,
+      lineWrapping: true
+    });
+    this.codeMirror.on("change", (codeMirror, change) => {
+      this.data = this.codeMirror.getValue();
+      this.change();
+    });
+  }
+}

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -46,6 +46,17 @@
     ></schema-editor-boolean>
   </div>
 
+  <div if.bind="getType(schema) === 'code'" class="schema-editor-block">
+    <require from="./schema-editor-code"></require>
+    <schema-editor-code
+      schema.bind="schema"
+      data.two-way="data"
+      change.bind="change"
+      required.bind="required"
+      show-notifications.bind="showNotifications"
+    ></schema-editor-code>
+  </div>
+
   <div if.bind="getType(schema) === 'url'" class="schema-editor-block">
     <require from="./schema-editor-url"></require>
     <schema-editor-url

--- a/client/src/livingdocs-component-app/app.html
+++ b/client/src/livingdocs-component-app/app.html
@@ -23,7 +23,7 @@
         <div class="item-list-entry ${item.conf._id === selectedItem.id ? 'selected' : ''}" click.delegate="selectItem(item)"
           repeat.for="item of items">
           <div class="item-list-entry-title">
-            <box-icon if.bind="item.conf.icon" code.bind="item.conf.icon" size="big" class="tool-icon"></box-icon>
+            <box-icon if.bind="item.toolConfig.icon" code.bind="item.toolConfig.icon" size="big" class="tool-icon"></box-icon>
             <span class="q-text">${item.conf.title}</span>
           </div>
           <div class="item-list-entry-info">

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -38,7 +38,6 @@ export class App {
   }
 
   async attached() {
-    debugger;
     this.QServerBaseUrl = await qEnv.QServerBaseUrl;
     this.tools = await this.getTools();
     this.target = await this.getTarget();

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -38,6 +38,7 @@ export class App {
   }
 
   async attached() {
+    debugger;
     this.QServerBaseUrl = await qEnv.QServerBaseUrl;
     this.selectedItem = await this.getInitialSelectedItem();
     this.tools = await this.getTools();

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -130,7 +130,10 @@ export class App {
       });
 
       if (tool) {
-        item.conf.icon = tool.icon;
+        item.toolConfig = {
+          icon: tool.icon,
+          hasDynamicDisplayOptions: tool.hasDynamicDisplayOptions
+        };
       }
 
       return item;
@@ -145,6 +148,7 @@ export class App {
     this.selectedItem = {
       id: item.conf._id,
       conf: item.conf,
+      toolConfig: item.toolConfig,
       toolRuntimeConfig: {}
     };
     if (this.selectedItem.conf.active) {
@@ -172,8 +176,9 @@ export class App {
         }
       );
     }
-    // delete the conf property of the selectedItem before saving it with the item
+    // delete the conf and toolConfig properties of the selectedItem before saving it with the item
     delete this.selectedItem.conf;
+    delete this.selectedItem.toolConfig;
     const message = {
       action: "update",
       params: this.selectedItem
@@ -197,10 +202,17 @@ export class App {
   async getDisplayOptionsSchema() {
     try {
       let displayOptionsSchema = {};
+      let queryString = "";
+
+      // if the tool supports dynamic displayOptions the item should be appended to the request
+      // in order for the tool to extract the displayOptionsSchema from the item
+      if (this.selectedItem.toolConfig.hasDynamicDisplayOptions) {
+        queryString = `?appendItemToPayload=${this.selectedItem.id}`;
+      }
       const response = await fetch(
         `${this.QServerBaseUrl}/tools/${
           this.selectedItem.conf.tool
-        }/display-options-schema.json`
+        }/display-options-schema.json${queryString}`
       );
       if (response.ok) {
         displayOptionsSchema = await response.json();

--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -40,10 +40,10 @@ export class App {
   async attached() {
     debugger;
     this.QServerBaseUrl = await qEnv.QServerBaseUrl;
-    this.selectedItem = await this.getInitialSelectedItem();
     this.tools = await this.getTools();
     this.target = await this.getTarget();
     this.items = await this.getItems();
+    this.selectedItem = await this.getInitialSelectedItem();
     if (this.selectedItem) {
       await this.loadPreview();
     }
@@ -107,6 +107,7 @@ export class App {
     try {
       const response = await fetch(`${this.QServerBaseUrl}/item/${params.id}`);
       params.conf = await response.json();
+      params.toolConfig = this.getToolConfig(params.conf);
       return params;
     } catch (error) {
       log.error(error);
@@ -124,25 +125,30 @@ export class App {
       bookmark
     );
 
-    // sets tool icon to item
+    // sets toolConfig to items
     result.items = result.items.map(item => {
-      let tool = this.tools.find(toolItem => {
-        return toolItem.name === item.getToolName();
-      });
-
-      if (tool) {
-        item.toolConfig = {
-          icon: tool.icon,
-          hasDynamicDisplayOptions: tool.hasDynamicDisplayOptions
-        };
-      }
-
+      item.toolConfig = this.getToolConfig(item.conf);
       return item;
     });
     this.bookmark = result.bookmark;
     this.moreItemsAvailable = result.moreItemsAvailable;
     this.itemsLoading = false;
     return result.items;
+  }
+
+  getToolConfig(itemConf) {
+    let toolConfig = {};
+    let tool = this.tools.find(toolItem => {
+      return toolItem.name === itemConf.tool;
+    });
+
+    if (tool) {
+      toolConfig = {
+        icon: tool.icon,
+        hasDynamicDisplayOptions: tool.hasDynamicDisplayOptions
+      };
+    }
+    return toolConfig;
   }
 
   async selectItem(item) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
- feature: new schema-editor-code (`"Q:type": "code"`) using codemirror to show a code editor, currently supports javascript and html mime types.
- feature: `appendItemToPayload` is used appended to the request for `display-options-schema.json` in livingdocs-component if tool config sets `hasDynamicDisplayOptions` to true.
