### PR TITLE
(schema-editor-code): load css codemirror module

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-code.js
+++ b/client/src/elements/schema-editor/schema-editor-code.js
@@ -50,7 +50,8 @@ export class SchemaEditorCode {
           this.loader.loadModule(
             "npm:codemirror@5.41.0/mode/htmlmixed/htmlmixed.js"
           ),
-          this.loader.loadModule("npm:codemirror@5.41.0/mode/jinja2/jinja2.js")
+          this.loader.loadModule("npm:codemirror@5.41.0/mode/jinja2/jinja2.js"),
+          this.loader.loadModule("npm:codemirror@5.41.0/mode/css/css.js")
         ]);
       } catch (e) {
         log.error(e);


### PR DESCRIPTION
- this makes the mime type `text/css` correctly syntax highlighted in schema-editor-code
- not deployed but can be locally tested by adding a string with `"Q:type": "code"` and `"mimeType":"text/css"` in the `Q:options` to any tool schema (likely to be used in Q-custom-code).

@manuelroth I would like to merge this to dev and release later with the tasks feature currently in development if we do not need it earlier on prod.