### PR TITLE
Release 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 3.7.1 (03.12.2018)
+- fix: load css codemirror module
+- fix: fix default binding for objects on schema-editor to not fail if top level object is undefined (e.g. new options property on item)
+
 # 3.7.0 (21.11.2018)
 - feature: new schema-editor-code (`"Q:type": "code"`) using codemirror to show a code editor, currently supports javascript and html mime types.
 - feature: `appendItemToPayload` is used appended to the request for `display-options-schema.json` in livingdocs-component if tool config sets `hasDynamicDisplayOptions` to true.

--- a/client/src/elements/schema-editor/schema-editor-code.js
+++ b/client/src/elements/schema-editor/schema-editor-code.js
@@ -50,7 +50,8 @@ export class SchemaEditorCode {
           this.loader.loadModule(
             "npm:codemirror@5.41.0/mode/htmlmixed/htmlmixed.js"
           ),
-          this.loader.loadModule("npm:codemirror@5.41.0/mode/jinja2/jinja2.js")
+          this.loader.loadModule("npm:codemirror@5.41.0/mode/jinja2/jinja2.js"),
+          this.loader.loadModule("npm:codemirror@5.41.0/mode/css/css.js")
         ]);
       } catch (e) {
         log.error(e);

--- a/client/src/elements/schema-editor/schema-editor.js
+++ b/client/src/elements/schema-editor/schema-editor.js
@@ -1,8 +1,8 @@
-import { bindable } from "aurelia-framework";
+import { bindable, bindingMode } from "aurelia-framework";
 
 export class SchemaEditor {
   @bindable schema;
-  @bindable data;
+  @bindable({ defaultBindingMode: bindingMode.twoWay }) data;
   @bindable change;
   @bindable notifications;
   @bindable showNotifications;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
- fix: load css codemirror module
- fix: fix default binding for objects on schema-editor to not fail if top level object is undefined (e.g. new options property on item)

deployed on staging.