### PR TITLE
Fix preview container height

### DIFF
--- a/client/src/elements/item-preview/item-preview.css
+++ b/client/src/elements/item-preview/item-preview.css
@@ -32,6 +32,7 @@ item-preview {
 
 .item-preview__container {
   display: flex;
+  height: 100%;
 }
 
 .item-preview__notification {

--- a/client/src/elements/item-preview/item-preview.css
+++ b/client/src/elements/item-preview/item-preview.css
@@ -4,7 +4,7 @@ item-preview {
   --q-preview-settings-margin-bottom: calc(var(--q-space-base) * 2);
   display: block;
   position: relative;
-  min-height: calc(var(--q-preview-min-height) + (2 * var(--q-preview-padding)) + 50px + var(--q-preview-settings-margin-bottom) + 20px);
+  min-height: calc(var(--q-preview-min-height) + (2 * var(--q-preview-padding)) + 50px + var(--q-preview-settings-margin-bottom));
 }
 
 .item-preview__holder {

--- a/client/src/livingdocs-component-app/app.css
+++ b/client/src/livingdocs-component-app/app.css
@@ -223,6 +223,8 @@ html {
   --preview-container-overflow-y: hidden;
   --preview-container-margin-top: 0px;
   margin: 0;
+  height: 1px; /* set a fixed height so the container doesn't grow infinitely but stays within the flex container */
+  flex-grow: 1; /* let the preview-container grow to the remaining space */
 }
 
 .livingdocs-component-item-controls {


### PR DESCRIPTION
- this stops the preview container from growing to overlap it's container in height
- deployed on staging and to be tested by selecting items that are very high in the livingdocs-component or in Q editor