### PR TITLE
Feat schema editor structure improvements

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-array.css
+++ b/client/src/elements/schema-editor/schema-editor-array.css
@@ -27,6 +27,8 @@ schema-editor-array {
   .schema-editor-array__control {
   order: 1;
   margin-left: var(--q-space-base);
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .schema-editor-array__entry-container--expandable

--- a/client/src/elements/schema-editor/schema-editor-array.css
+++ b/client/src/elements/schema-editor/schema-editor-array.css
@@ -18,10 +18,24 @@ schema-editor-array {
   flex-wrap: wrap;
 }
 
+.schema-editor-array__entry-container--compact {
+  display: flex;
+  flex-direction: row;
+}
+
+.schema-editor-array__entry-container--compact:not(.schema-editor-array__entry-container--expandable)
+  .schema-editor-array__control {
+  order: 1;
+  margin-left: var(--q-space-base);
+}
+
+.schema-editor-array__entry-container--expandable
+  .schema-editor-array__control {
+  width: 100%;
+}
+
 .schema-editor-array__control {
-  margin-top: calc(var(--q-space-base) * 2);
-  padding-top: calc(var(--q-space-base) * 2);
-  border-top: 1px solid var(--q-color-gray-4);
+  margin-top: calc(var(--q-space-base) * 3);
 }
 
 .schema-editor-array__collapsecontrol {
@@ -42,6 +56,13 @@ schema-editor-array {
   flex-grow: 1;
   z-index: 1; /* stay below collapsecontrol */
   margin-top: var(--q-space-base);
+}
+
+/* if the array entry is expandable, we add intentation to right-align it with the expand/collapse button */
+.schema-editor-array__entry
+  > .schema-editor-array__entry-container--expandable
+  > schema-editor-wrapper {
+  padding-left: calc(var(--q-space-base) * 4);
 }
 
 .schema-editor-array__button-container {

--- a/client/src/elements/schema-editor/schema-editor-array.html
+++ b/client/src/elements/schema-editor/schema-editor-array.html
@@ -1,43 +1,110 @@
 <template>
   <require from="./schema-editor-wrapper"></require>
   <require from="./schema-editor-array.css"></require>
-  <legend>
+  <label>
     ${schema.title & toolT}
-  </legend>
-  <div if.bind="data" repeat.for="entry of data" class="schema-editor-array__entry" style="z-index: ${data.length - $index}">
+  </label>
+  <div
+    if.bind="data"
+    repeat.for="entry of data"
+    class="schema-editor-array__entry"
+    style="z-index: ${data.length - $index}"
+  >
     <div class="schema-editor-array__entry-container">
-      <div class="schema-editor-array__control ${showNotifications ? 'schema-editor-input--with-notifications' : ''}">
-        <div class="schema-editor-array__collapsecontrol" if.bind="options.expandable && isEntryAvailable($index) & async">
-          <button-secondary icon="expand" size="small" if.bind="collapsedStates[$index] !== 'expanded'" click.delegate="expand($index)"></button-secondary>
-          <button-secondary icon="collapse" size="small" if.bind="collapsedStates[$index] === 'expanded'" click.delegate="collapse($index)"></button-secondary>
+      <div
+        class="schema-editor-array__control ${showNotifications ? 'schema-editor-input--with-notifications' : ''}"
+      >
+        <div
+          class="schema-editor-array__collapsecontrol"
+          if.bind="options.expandable && isEntryAvailable($index) & async"
+        >
+          <button-secondary
+            icon="expand"
+            size="small"
+            if.bind="collapsedStates[$index] !== 'expanded'"
+            click.delegate="expand($index)"
+          ></button-secondary>
+          <button-secondary
+            icon="collapse"
+            size="small"
+            if.bind="collapsedStates[$index] === 'expanded'"
+            click.delegate="collapse($index)"
+          ></button-secondary>
 
-          <span class="q-text" if.bind="options.expandable.itemLabelProperty && entryLabels[$index]" innerhtml.bind="entryLabels[$index]"></span>
-          <span class="q-text" if.bind="!options.expandable.itemLabelProperty || !entryLabels[$index]">${$index + 1}</span>
+          <span
+            class="q-text"
+            if.bind="options.expandable.itemLabelProperty && entryLabels[$index]"
+            innerhtml.bind="entryLabels[$index]"
+          ></span>
+          <span
+            class="q-text"
+            if.bind="!options.expandable.itemLabelProperty || !entryLabels[$index]"
+            >${$index + 1}</span
+          >
           <div class="schema-editor-array__entry-actions">
-            <button-tertiary if.bind="!$first" icon="up" click.delegate="moveElementUp($index)" size="small"></button-tertiary>
-            <button-tertiary if.bind="!$last" icon="down" click.delegate="moveElementDown($index)" size="small"></button-tertiary>
-            <button-secondary class="schema-editor-array__button" click.delegate="deleteElement($index)">
+            <button-tertiary
+              if.bind="!$first"
+              icon="up"
+              click.delegate="moveElementUp($index)"
+              size="small"
+            ></button-tertiary>
+            <button-tertiary
+              if.bind="!$last"
+              icon="down"
+              click.delegate="moveElementDown($index)"
+              size="small"
+            ></button-tertiary>
+            <button-secondary
+              class="schema-editor-array__button"
+              click.delegate="deleteElement($index)"
+            >
               ${'editor.arrayEntryRemove' & t: getArrayEntryOption($index)}
             </button-secondary>
           </div>
         </div>
-        <div class="schema-editor-array__entry-actions" if.bind="!options.expandable">
-          <button-tertiary if.bind="!$first" icon="up" click.delegate="moveElementUp($index)" size="small"></button-tertiary>
-          <button-tertiary if.bind="!$last" icon="down" click.delegate="moveElementDown($index)" size="small"></button-tertiary>
-          <button-secondary class="schema-editor-array__button" click.delegate="deleteElement($index)">
+        <div
+          class="schema-editor-array__entry-actions"
+          if.bind="!options.expandable"
+        >
+          <button-tertiary
+            if.bind="!$first"
+            icon="up"
+            click.delegate="moveElementUp($index)"
+            size="small"
+          ></button-tertiary>
+          <button-tertiary
+            if.bind="!$last"
+            icon="down"
+            click.delegate="moveElementDown($index)"
+            size="small"
+          ></button-tertiary>
+          <button-secondary
+            class="schema-editor-array__button"
+            click.delegate="deleteElement($index)"
+          >
             ${'editor.arrayEntryRemove' & t: getArrayEntryOption($index)}
           </button-secondary>
         </div>
       </div>
-      <schema-editor-wrapper class="schema-editor-array__schema-editor-wrapper" if.bind="(collapsedStates[$index] === 'expanded' || !options.expandable) && isEntryAvailable($index) & async"
-        schema.bind="dataItemsSchemas[$index]" data.two-way="data[$index]" change.bind="$parent.handleChange" no-object-title="true"
-        notifications.bind="notifications" show-notifications.bind="showNotifications">
+      <schema-editor-wrapper
+        class="schema-editor-array__schema-editor-wrapper"
+        if.bind="(collapsedStates[$index] === 'expanded' || !options.expandable) && isEntryAvailable($index) & async"
+        schema.bind="dataItemsSchemas[$index]"
+        data.two-way="data[$index]"
+        change.bind="$parent.handleChange"
+        no-object-title="true"
+        notifications.bind="notifications"
+        show-notifications.bind="showNotifications"
+      >
       </schema-editor-wrapper>
     </div>
   </div>
   <div class="schema-editor-array__button-container">
-    <button-primary class="schema-editor-array__button schema-editor-array__add-button" repeat.for="arrayEntryOption of arrayEntryOptions"
-      click.delegate="addElement(arrayEntryOption.schema)">
+    <button-primary
+      class="schema-editor-array__button schema-editor-array__add-button"
+      repeat.for="arrayEntryOption of arrayEntryOptions"
+      click.delegate="addElement(arrayEntryOption.schema)"
+    >
       ${'editor.arrayEntryAdd' & t: arrayEntryOption}
     </button-primary>
   </div>

--- a/client/src/elements/schema-editor/schema-editor-array.html
+++ b/client/src/elements/schema-editor/schema-editor-array.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./schema-editor-wrapper"></require>
   <require from="./schema-editor-array.css"></require>
-  <label>
+  <label class="input-group-title">
     ${schema.title & toolT}
   </label>
   <div
@@ -10,7 +10,9 @@
     class="schema-editor-array__entry"
     style="z-index: ${data.length - $index}"
   >
-    <div class="schema-editor-array__entry-container">
+    <div
+      class="schema-editor-array__entry-container ${options.expandable ? 'schema-editor-array__entry-container--expandable' : ''} ${options.layout === 'compact' ? 'schema-editor-array__entry-container--compact' : ''}"
+    >
       <div
         class="schema-editor-array__control ${showNotifications ? 'schema-editor-input--with-notifications' : ''}"
       >
@@ -33,23 +35,23 @@
 
           <span
             class="q-text"
-            if.bind="options.expandable.itemLabelProperty && entryLabels[$index]"
+            if.bind="(options.expandable.itemLabelProperty || options.expandable.itemLabelTemplate) && entryLabels[$index]"
             innerhtml.bind="entryLabels[$index]"
           ></span>
           <span
             class="q-text"
-            if.bind="!options.expandable.itemLabelProperty || !entryLabels[$index]"
+            else
             >${$index + 1}</span
           >
           <div class="schema-editor-array__entry-actions">
             <button-tertiary
-              if.bind="!$first"
+              if.bind="!$first && options.sortable"
               icon="up"
               click.delegate="moveElementUp($index)"
               size="small"
             ></button-tertiary>
             <button-tertiary
-              if.bind="!$last"
+              if.bind="!$last && options.sortable"
               icon="down"
               click.delegate="moveElementDown($index)"
               size="small"
@@ -57,8 +59,16 @@
             <button-secondary
               class="schema-editor-array__button"
               click.delegate="deleteElement($index)"
+              if.bind="options.layout !== 'compact'"
             >
               ${'editor.arrayEntryRemove' & t: getArrayEntryOption($index)}
+            </button-secondary>
+            <button-secondary
+              click.delegate="deleteElement($index)"
+              icon="delete"
+              if.bind="options.layout === 'compact'"
+              size="small"
+            >
             </button-secondary>
           </div>
         </div>
@@ -67,23 +77,30 @@
           if.bind="!options.expandable"
         >
           <button-tertiary
-            if.bind="!$first"
+            if.bind="!$first && options.sortable"
             icon="up"
             click.delegate="moveElementUp($index)"
             size="small"
           ></button-tertiary>
           <button-tertiary
-            if.bind="!$last"
+            if.bind="!$last && options.sortable"
             icon="down"
             click.delegate="moveElementDown($index)"
             size="small"
           ></button-tertiary>
           <button-secondary
-            class="schema-editor-array__button"
-            click.delegate="deleteElement($index)"
-          >
-            ${'editor.arrayEntryRemove' & t: getArrayEntryOption($index)}
-          </button-secondary>
+              class="schema-editor-array__button"
+              click.delegate="deleteElement($index)"
+              if.bind="options.layout !== 'compact'"
+            >
+              ${'editor.arrayEntryRemove' & t: getArrayEntryOption($index)}
+            </button-secondary>
+            <button-secondary
+              click.delegate="deleteElement($index)"
+              icon="delete"
+              if.bind="options.layout === 'compact'"
+              size="small"
+            >
         </div>
       </div>
       <schema-editor-wrapper

--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -18,9 +18,7 @@ export class SchemaEditorArray {
   // these are the defaults
   options = {
     expandable: false,
-    layout: {
-      compact: false
-    },
+    layout: "default",
     sortable: true
   };
 

--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -222,7 +222,10 @@ export class SchemaEditorArray {
         for (const match of variableMatches) {
           entryLabel = entryLabel.replace(
             match,
-            this.getEntryLabel(entry, match.replace("${", "").replace("}", ""))
+            this.getEntryLabel(
+              entry,
+              match.replace("${", "").replace("}", "")
+            ) || ""
           );
         }
         return entryLabel;

--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -15,8 +15,13 @@ export class SchemaEditorArray {
 
   arrayEntryOptions = [];
 
+  // these are the defaults
   options = {
-    expandable: false
+    expandable: false,
+    layout: {
+      compact: false
+    },
+    sortable: true
   };
 
   collapsedStates = {};
@@ -71,6 +76,9 @@ export class SchemaEditorArray {
     if (this.data === undefined) {
       this.data = [];
       this.dataItemsSchemas = [];
+    }
+    if (!Array.isArray(this.dataItemsSchemas)) {
+      this.dataChanged();
     }
     const entry = this.objectFromSchemaGenerator.generateFromSchema(schema);
 
@@ -204,6 +212,33 @@ export class SchemaEditorArray {
           this.options.expandable.itemLabelProperty
         );
       }
+
+      if (this.options.expandable.itemLabelTemplate) {
+        const variableMatches = this.options.expandable.itemLabelTemplate.match(
+          /\${[a-zA-Z.]*}/gm
+        );
+        if (variableMatches === null) {
+          return this.options.expandable.itemLabelTemplate;
+        }
+        let entryLabel = this.options.expandable.itemLabelTemplate;
+        for (const match of variableMatches) {
+          entryLabel = entryLabel.replace(
+            match,
+            this.getEntryLabel(entry, match.replace("${", "").replace("}", ""))
+          );
+        }
+        return entryLabel;
+      }
+
+      // TODO: REMOVE THIS:
+      // if (Array.isArray(this.options.expandable.itemLabelProperties)) {
+      //   return this.options.expandable.itemLabelProperties
+      //     .map(itemLabelProperty => {
+      //       return "" + this.getEntryLabel(entry, itemLabelProperty);
+      //     })
+      //     .join(" - ");
+      // }
+
       return undefined;
     });
   }

--- a/client/src/elements/schema-editor/schema-editor-array.js
+++ b/client/src/elements/schema-editor/schema-editor-array.js
@@ -230,15 +230,6 @@ export class SchemaEditorArray {
         return entryLabel;
       }
 
-      // TODO: REMOVE THIS:
-      // if (Array.isArray(this.options.expandable.itemLabelProperties)) {
-      //   return this.options.expandable.itemLabelProperties
-      //     .map(itemLabelProperty => {
-      //       return "" + this.getEntryLabel(entry, itemLabelProperty);
-      //     })
-      //     .join(" - ");
-      // }
-
       return undefined;
     });
   }

--- a/client/src/elements/schema-editor/schema-editor-object.css
+++ b/client/src/elements/schema-editor/schema-editor-object.css
@@ -1,0 +1,8 @@
+.schema-editor-object__header {
+  display: flex;
+  align-items: center;
+}
+
+.schema-editor-object__header__controls {
+  padding-right: var(--q-space-base);
+}

--- a/client/src/elements/schema-editor/schema-editor-object.html
+++ b/client/src/elements/schema-editor/schema-editor-object.html
@@ -1,14 +1,35 @@
 <template style="display: block">
+  <require from="./schema-editor-object.css!"></require>
   <require from="./schema-editor-wrapper"></require>
-  <legend if.bind="!noObjectTitle">
-    ${schema.title & toolT}
-  </legend>
+  <div class="schema-editor-object__header">
+    <div
+      if.bind="options.expandable"
+      class="schema-editor-object__header__controls"
+    >
+      <button-secondary
+        icon="expand"
+        size="small"
+        if.bind="collapsedState !== 'expanded'"
+        click.delegate="expand()"
+      ></button-secondary>
+      <button-secondary
+        icon="collapse"
+        size="small"
+        if.bind="collapsedState === 'expanded'"
+        click.delegate="collapse()"
+      ></button-secondary>
+    </div>
+    <label if.bind="!noObjectTitle" class="input-group-title">
+      ${schema.title & toolT}
+    </label>
+  </div>
+
   <div
     if.bind="schema.properties"
     repeat.for="propertyName of schema.properties | keys"
   >
     <fieldset
-      if.bind="noFieldsets || getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array'"
+      if.bind="(collapsedState === 'expanded' || !options.expandable) && (getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array')"
       class="${isCompact($parent.schema.properties[propertyName]) ? 'compact' : ''}"
     >
       <schema-editor-wrapper
@@ -24,7 +45,7 @@
     </fieldset>
 
     <schema-editor-wrapper
-      if.bind="(!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor) && getType($parent.schema.properties[propertyName]) !== 'object' && getType($parent.schema.properties[propertyName]) !== 'array'"
+      if.bind="(collapsedState === 'expanded' || !options.expandable) && (!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor) && getType($parent.schema.properties[propertyName]) !== 'object' && getType($parent.schema.properties[propertyName]) !== 'array'"
       schema.bind="$parent.schema.properties[propertyName]"
       data.two-way="$parent.data[propertyName]"
       change.bind="$parent.change"

--- a/client/src/elements/schema-editor/schema-editor-object.html
+++ b/client/src/elements/schema-editor/schema-editor-object.html
@@ -1,5 +1,5 @@
 <template style="display: block">
-  <require from="./schema-editor-object.css!"></require>
+  <require from="./schema-editor-object.css"></require>
   <require from="./schema-editor-wrapper"></require>
   <div class="schema-editor-object__header">
     <div

--- a/client/src/elements/schema-editor/schema-editor-object.html
+++ b/client/src/elements/schema-editor/schema-editor-object.html
@@ -1,30 +1,37 @@
 <template style="display: block">
-    <require from="./schema-editor-wrapper"></require>
-    <legend if.bind="!noObjectTitle">
-      ${schema.title & toolT}
-    </legend>
-    <div if.bind="schema.properties" repeat.for="propertyName of schema.properties | keys">
-      <fieldset if.bind="noFieldsets || getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array'" class="${isCompact($parent.schema.properties[propertyName]) ? 'compact' : ''}">
-        <schema-editor-wrapper
-            if.bind="!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor"
-            schema.bind="$parent.schema.properties[propertyName]"
-            data.two-way="$parent.data[propertyName]"
-            change.bind="$parent.change"
-            required.bind="isRequired($parent.schema, propertyName)"
-            notifications.bind="notifications"
-            show-notifications.bind="showNotifications">
-        </schema-editor-wrapper>
-      </fieldset>
-
+  <require from="./schema-editor-wrapper"></require>
+  <legend if.bind="!noObjectTitle">
+    ${schema.title & toolT}
+  </legend>
+  <div
+    if.bind="schema.properties"
+    repeat.for="propertyName of schema.properties | keys"
+  >
+    <fieldset
+      if.bind="noFieldsets || getType($parent.schema.properties[propertyName]) === 'object' || getType($parent.schema.properties[propertyName]) === 'array'"
+      class="${isCompact($parent.schema.properties[propertyName]) ? 'compact' : ''}"
+    >
       <schema-editor-wrapper
-        if.bind="(!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor) && getType($parent.schema.properties[propertyName]) !== 'object' && getType($parent.schema.properties[propertyName]) !== 'array'"
+        if.bind="!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor"
         schema.bind="$parent.schema.properties[propertyName]"
         data.two-way="$parent.data[propertyName]"
         change.bind="$parent.change"
         required.bind="isRequired($parent.schema, propertyName)"
         notifications.bind="notifications"
-        show-notifications.bind="showNotifications">
+        show-notifications.bind="showNotifications"
+      >
       </schema-editor-wrapper>
+    </fieldset>
 
-    </div>
+    <schema-editor-wrapper
+      if.bind="(!$parent.schema.properties[propertyName]['Q:options'] || !$parent.schema.properties[propertyName]['Q:options'].hideInEditor) && getType($parent.schema.properties[propertyName]) !== 'object' && getType($parent.schema.properties[propertyName]) !== 'array'"
+      schema.bind="$parent.schema.properties[propertyName]"
+      data.two-way="$parent.data[propertyName]"
+      change.bind="$parent.change"
+      required.bind="isRequired($parent.schema, propertyName)"
+      notifications.bind="notifications"
+      show-notifications.bind="showNotifications"
+    >
+    </schema-editor-wrapper>
+  </div>
 </template>

--- a/client/src/elements/schema-editor/schema-editor-object.js
+++ b/client/src/elements/schema-editor/schema-editor-object.js
@@ -15,6 +15,12 @@ export class SchemaEditorObject {
   @bindable
   showNotifications;
 
+  options = {
+    expandable: false
+  };
+
+  collapsedState = "collapsed";
+
   constructor() {
     this.getType = getType;
     this.isRequired = isRequired;
@@ -28,6 +34,17 @@ export class SchemaEditorObject {
     if (this.data === undefined) {
       this.data = {};
     }
+    this.applyOptions();
+  }
+
+  schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
   }
 
   isCompact(schema) {
@@ -35,5 +52,13 @@ export class SchemaEditorObject {
       return true;
     }
     return false;
+  }
+
+  expand() {
+    this.collapsedState = "expanded";
+  }
+
+  collapse() {
+    this.collapsedState = "collapsed";
   }
 }

--- a/client/src/elements/schema-editor/schema-editor-select.html
+++ b/client/src/elements/schema-editor/schema-editor-select.html
@@ -1,14 +1,12 @@
 <template class="schema-editor-input ${showNotifications ? 'schema-editor-input--with-notifications' : ''}">
-  <label>
-    ${schema["title"] & toolT}
-    <select value.bind="data" change.delegate="change()" if.bind="selectType === 'select'">
-      <option repeat.for="option of schema.enum" model.bind="option">${optionLabels[$index] & toolT}</option>
-    </select>
-    <div if.bind="selectType === 'radio'">
-      <div repeat.for="option of schema.enum" class="q-form__radio">
-        <input id="option-${option}" type="radio" name.bind="$parent.schema.title" model.bind="option" checked.bind="$parent.data" change.delegate="change()"></input>
-        <label for="option-${option}">${optionLabels[$index] & toolT}</label>
-      </div>
+  <label class="${selectType === 'radio' ? 'input-group-title' : ''}">${schema["title"] & toolT}</label>
+  <select value.bind="data" change.delegate="change()" if.bind="selectType === 'select'">
+    <option repeat.for="option of schema.enum" model.bind="option">${optionLabels[$index] & toolT}</option>
+  </select>
+  <div if.bind="selectType === 'radio'">
+    <div repeat.for="option of schema.enum" class="q-form__radio">
+      <input id="option-${option}" type="radio" name.bind="$parent.schema.title" model.bind="option" checked.bind="$parent.data" change.delegate="change()"></input>
+      <label for="option-${option}">${optionLabels[$index] & toolT}</label>
     </div>
-  </label>
+  </div>
 </template>

--- a/client/src/elements/schema-editor/schema-editor.css
+++ b/client/src/elements/schema-editor/schema-editor.css
@@ -28,6 +28,10 @@ schema-editor fieldset fieldset.compact > schema-editor-wrapper {
   margin-bottom: calc(var(--q-space-base) * 2);
 }
 
+.input-group-title {
+  margin: calc(var(--q-space-base) * 2) 0 var(--q-space-base) 0;
+}
+
 schema-editor-wrapper .input-group-title {
   font-size: var(--q-h2-size);
   font-weight: var(--q-h2-weight);

--- a/client/src/elements/schema-editor/schema-editor.css
+++ b/client/src/elements/schema-editor/schema-editor.css
@@ -23,40 +23,6 @@ schema-editor fieldset fieldset.compact > schema-editor-wrapper {
   margin-top: var(--q-space-base);
 }
 
-schema-editor-wrapper legend {
-  font-size: var(--q-h2-size);
-  font-weight: var(--q-h2-weight);
-}
-
-schema-editor-wrapper schema-editor-wrapper legend {
-  font-size: var(--q-h3-size);
-  font-weight: var(--q-h3-weight);
-}
-
-schema-editor-wrapper schema-editor-wrapper schema-editor-wrapper legend {
-  font-size: var(--q-h4-size);
-  font-weight: var(--q-h4-weight);
-}
-
-schema-editor-wrapper
-  schema-editor-wrapper
-  schema-editor-wrapper
-  schema-editor-wrapper
-  legend {
-  font-size: var(--q-h5-size);
-  font-weight: var(--q-h5-weight);
-}
-
-schema-editor-wrapper
-  schema-editor-wrapper
-  schema-editor-wrapper
-  schema-editor-wrapper
-  schema-editor-wrapper
-  legend {
-  font-size: var(--q-h5-size);
-  font-weight: var(--q-h5-weight);
-}
-
 .schema-editor-input {
   display: block;
   margin-bottom: calc(var(--q-space-base) * 2);

--- a/client/src/elements/schema-editor/schema-editor.css
+++ b/client/src/elements/schema-editor/schema-editor.css
@@ -27,3 +27,40 @@ schema-editor fieldset fieldset.compact > schema-editor-wrapper {
   display: block;
   margin-bottom: calc(var(--q-space-base) * 2);
 }
+
+schema-editor-wrapper .input-group-title {
+  font-size: var(--q-h2-size);
+  font-weight: var(--q-h2-weight);
+}
+
+schema-editor-wrapper schema-editor-wrapper .input-group-title {
+  font-size: var(--q-h3-size);
+  font-weight: var(--q-h3-weight);
+}
+
+schema-editor-wrapper
+  schema-editor-wrapper
+  schema-editor-wrapper
+  .input-group-title {
+  font-size: var(--q-h4-size);
+  font-weight: var(--q-h4-weight);
+}
+
+schema-editor-wrapper
+  schema-editor-wrapper
+  schema-editor-wrapper
+  schema-editor-wrapper
+  .input-group-title {
+  font-size: var(--q-h5-size);
+  font-weight: var(--q-h5-weight);
+}
+
+schema-editor-wrapper
+  schema-editor-wrapper
+  schema-editor-wrapper
+  schema-editor-wrapper
+  schema-editor-wrapper
+  .input-group-title {
+  font-size: var(--q-h5-size);
+  font-weight: var(--q-h5-weight);
+}

--- a/client/src/pages/editor.css
+++ b/client/src/pages/editor.css
@@ -37,8 +37,8 @@
   display: block;
   margin: calc(var(--q-space-base)) 0;
 
-  font-size: var(--q-h4-size);
-  font-weight: var(--q-h4-weight);
+  font-size: var(--q-h4-size) !important;
+  font-weight: var(--q-h4-weight) !important;
   color: var(--q-text-color);
   margin-bottom: var(--q-space-base);
 }

--- a/client/src/pages/editor.css
+++ b/client/src/pages/editor.css
@@ -40,7 +40,6 @@
   font-size: var(--q-h4-size) !important;
   font-weight: var(--q-h4-weight) !important;
   color: var(--q-text-color);
-  margin-bottom: var(--q-space-base);
 }
 
 .editor__options .schema-editor-input {

--- a/client/src/pages/editor.css
+++ b/client/src/pages/editor.css
@@ -24,48 +24,49 @@
   flex-direction: column;
 }
 
-.editor__preview .editor__options {
+.editor__options {
   width: 250px;
   flex-grow: 0;
   flex-shrink: 0;
   margin-right: calc(var(--q-space-base) * 2);
   overflow-y: auto;
-  --q-h1-size: 13px;
-  --q-h2-size: 13px;
-  --q-h3-size: 13px;
-  --q-h4-size: 13px;
-  --q-h5-size: 13px;
-  --q-h6-size: 13px;
+}
+
+.editor__options .input-group-title {
+  width: 100%;
+  display: block;
+  margin: calc(var(--q-space-base)) 0;
+
+  font-size: var(--q-h4-size);
+  font-weight: var(--q-h4-weight);
+  color: var(--q-text-color);
+  margin-bottom: var(--q-space-base);
 }
 
 .editor__options .schema-editor-input {
   margin-bottom: var(--q-space-base);
 }
 
-.editor__options legend {
-  width: 100%;
-  margin-top: calc(var(--q-space-base) * 2);
-
-  /* the following properties are copied from h6 style */
-  font-size: var(--q-h6-size);
-  font-weight: var(--q-h6-weight);
-  color: var(--q-text-light-color);
-  margin-bottom: var(--q-space-base);
+/* make the options more compact by removing the margin around schema-editor s */
+.editor__options schema-editor fieldset > schema-editor-wrapper {
+  margin: 0;
 }
 
-/* make the options more compact by removing the margin around fieldsets */
-.editor__options fieldset > schema-editor-wrapper {
-  margin: 0 !important;
-}
-
-.editor__options schema-editor-wrapper {
+.editor__options schema-editor schema-editor-wrapper {
   margin-bottom: 0;
 }
 
+.editor__options schema-editor schema-editor-wrapper schema-editor-wrapper {
+  border-bottom: 1px solid var(--q-color-gray-4);
+  margin-bottom: calc(var(--q-space-base) * 2);
+}
+
 .editor__options
+  schema-editor
   schema-editor-wrapper
   schema-editor-wrapper
   schema-editor-wrapper {
+  border: none;
   margin-bottom: 0;
 }
 

--- a/client/src/pages/editor.css
+++ b/client/src/pages/editor.css
@@ -58,6 +58,7 @@
 .editor__options schema-editor schema-editor-wrapper schema-editor-wrapper {
   border-bottom: 1px solid var(--q-color-gray-4);
   margin-bottom: calc(var(--q-space-base) * 2);
+  padding-bottom: var(--q-space-base);
 }
 
 .editor__options
@@ -67,6 +68,7 @@
   schema-editor-wrapper {
   border: none;
   margin-bottom: 0;
+  padding-bottom: 0;
 }
 
 .q-bar__back {

--- a/client/src/pages/editor.html
+++ b/client/src/pages/editor.html
@@ -48,7 +48,7 @@
                 notifications.bind="optionsNotifications"
                 show-notifications.bind="false"
               >
-                <h6>${optionsSchema.title || 'Optionen'}</h6>
+                <h6 if.bind="optionsSchema.title">${optionsSchema.title}</h6>
               </schema-editor>
               <button
                 ref="optionsFormSubmitButton"

--- a/client/src/pages/editor.html
+++ b/client/src/pages/editor.html
@@ -8,17 +8,32 @@
       <button-secondary icon="back" icon-size="medium"></button-secondary>
     </a>
     <language-switcher slot="language-switcher"></language-switcher>
-    <tool-status-bar slot="tool-status-bar" item.bind="item" save-action.call="userSave()" last-saved-date.bind="lastSavedDate"></tool-status-bar>
+    <tool-status-bar
+      slot="tool-status-bar"
+      item.bind="item"
+      save-action.call="userSave()"
+      last-saved-date.bind="lastSavedDate"
+    ></tool-status-bar>
   </q-bar>
   <main>
     <div class="editor">
       <section>
         <form ref="form" class="q-form" validate>
-          <schema-editor id="schema-editor--main" schema.bind="schema" data.bind="item.conf" change.call="handleChange()" notifications.bind="editorNotifications"
-            show-notifications.bind="true">
+          <schema-editor
+            id="schema-editor--main"
+            schema.bind="schema"
+            data.bind="item.conf"
+            change.call="handleChange()"
+            notifications.bind="editorNotifications"
+            show-notifications.bind="true"
+          >
             <h2>${ 'editor.title' & t }</h2>
           </schema-editor>
-          <button ref="formSubmitButton" type="submit" style="display: none;"></button>
+          <button
+            ref="formSubmitButton"
+            type="submit"
+            style="display: none;"
+          ></button>
         </form>
       </section>
       <section class="editor__preview-container">
@@ -26,23 +41,38 @@
         <div class="editor__preview">
           <div class="editor__options" if.bind="optionsSchema">
             <form ref="optionsForm" class="q-form" validate>
-              <schema-editor schema.bind="optionsSchema" data.bind="item.conf.options" change.call="handleChange()" notifications.bind="optionsNotifications"
-                show-notifications.bind="false">
+              <schema-editor
+                schema.bind="optionsSchema"
+                data.bind="item.conf.options"
+                change.call="handleChange()"
+                notifications.bind="optionsNotifications"
+                show-notifications.bind="false"
+              >
                 <h6>${optionsSchema.title || 'Optionen'}</h6>
               </schema-editor>
-              <button ref="optionsFormSubmitButton" type="submit" style="display: none;"></button>
+              <button
+                ref="optionsFormSubmitButton"
+                type="submit"
+                style="display: none;"
+              ></button>
             </form>
           </div>
           <item-preview data.bind="previewData">
             <div slot="notifications">
-              <notification repeat.for="notification of optionsNotifications" notification.bind="notification"></notification>
+              <notification
+                repeat.for="notification of optionsNotifications"
+                notification.bind="notification"
+              ></notification>
             </div>
           </item-preview>
         </div>
       </section>
       <section>
         <h2>${ 'metaEditor.title' & t }</h2>
-        <meta-editor data.bind="item.conf" change.call="handleChange()"></meta-editor>
+        <meta-editor
+          data.bind="item.conf"
+          change.call="handleChange()"
+        ></meta-editor>
       </section>
     </div>
   </main>

--- a/client/src/styles/config.css
+++ b/client/src/styles/config.css
@@ -41,7 +41,7 @@
   --q-h1-weight: 700;
   --q-h2-weight: 500;
   --q-h3-weight: 500;
-  --q-h4-weight: 400;
+  --q-h4-weight: 500;
   --q-h5-weight: 400;
   --q-h6-weight: 400;
 


### PR DESCRIPTION
- changes some of the css to improve the schema-editor visual structure in the options pane.
- adds a 2 layout options:

schema-editor-array supports
```
{
  "Q:options": {
    layout: "compact"
  }
}
```
This results in a more compact array layout, using an icon button to delete elements instead of a button with text.

schema-editor-object supports
```
{
  "Q:options": {
    expandable: true
  }
}
```

Resulting in the all input elements inside of an element being hidden behind an expand-button (as is already supported in schema-editor-array).

These new options are used in the upcoming Q-chart release and can be tested on testing env using the chart tool.