### PR TITLE
Release 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.0.3 (18.07.2019)
+
+- fix: load the additional editor stylesheets (used to load fonts needed for previews) in livingdocs-component.html to show a correct preview
+- fix: show the add element button in schema-editor-array if the array value is null
+
 # 4.0.2 (01.07.2019)
 
 - fix: show array entry add button if maxItems is defined but array is not yet defined

--- a/client/src/elements/schema-editor/schema-editor-array.html
+++ b/client/src/elements/schema-editor/schema-editor-array.html
@@ -121,7 +121,7 @@
       class="schema-editor-array__button schema-editor-array__add-button"
       repeat.for="arrayEntryOption of arrayEntryOptions"
       click.delegate="addElement(arrayEntryOption.schema)"
-      if.bind="schema.maxItems === undefined || data === undefined || schema.maxItems > data.length"
+      if.bind="schema.maxItems === undefined || data === undefined || data === null || schema.maxItems > data.length"
     >
       ${'editor.arrayEntryAdd' & t: arrayEntryOption}
     </button-primary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
- fix: load the additional editor stylesheets (used to load fonts needed for previews) in livingdocs-component.html to show a correct preview
- fix: show the add element button in schema-editor-array if the array value is null


This branch is deployed on stage environment.