### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 4.1.0 (05.09.2019)
+# 4.1.0 (06.09.2019)
 
 - feat: exportable targets. targets configured as exportable get a button on the item-overview page opening a modal allowing to download the renderingInfo of this target
 - feat: buttons take an isLoading parameter to show a spinner when they are busy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.1.0 (05.09.2019)
+
+- feat: exportable targets. targets configured as exportable get a button on the item-overview page opening a modal allowing to download the renderingInfo of this target
+- feat: buttons take an isLoading parameter to show a spinner when they are busy
+- fix: if the user has no default preview target defined through the publication config, the first available target is used for the preview
+
 # 4.0.3 (18.07.2019)
 
 - fix: load the additional editor stylesheets (used to load fonts needed for previews) in livingdocs-component.html to show a correct preview

--- a/client/config.js
+++ b/client/config.js
@@ -43,6 +43,7 @@ System.config({
     "core-js": "npm:core-js@1.2.7",
     "css": "github:systemjs/plugin-css@0.1.37",
     "dropzone": "npm:dropzone@5.5.1",
+    "file-saver": "npm:file-saver@2.0.2",
     "get-value": "npm:get-value@3.0.1",
     "handsontable": "github:handsontable/handsontable@5.0.2",
     "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",

--- a/client/package.json
+++ b/client/package.json
@@ -72,6 +72,7 @@
       "codemirror": "npm:codemirror@^5.41.0",
       "css": "github:systemjs/plugin-css@^0.1.32",
       "dropzone": "npm:dropzone@^5.5.1",
+      "file-saver": "npm:file-saver@^2.0.2",
       "get-value": "npm:get-value@^3.0.1",
       "handsontable": "github:handsontable/handsontable@^3.0.0",
       "heyman/leaflet-areaselect": "github:heyman/leaflet-areaselect@master",

--- a/client/src/dialogs/export-dialog.css
+++ b/client/src/dialogs/export-dialog.css
@@ -1,0 +1,7 @@
+.export-dialog schema-editor-select > div {
+  display: flex;
+}
+
+.export-dialog .q-form__radio {
+  margin-right: 8px;
+}

--- a/client/src/dialogs/export-dialog.html
+++ b/client/src/dialogs/export-dialog.html
@@ -1,0 +1,54 @@
+<template>
+  <require from="../styles/q-dialog.css"></require>
+  <require from="./export-dialog.css"></require>
+  <require from="elements/schema-editor/schema-editor"></require>
+  <require from="elements/item-preview/preview-container"></require>
+
+  <div
+    class="q-dialog q-dialog--centered q-dialog--bottom-controls export-dialog"
+  >
+    <button-tertiary
+      class="q-dialog__close-button"
+      icon="close"
+      icon-size="medium"
+      click.delegate="controller.cancel()"
+    ></button-tertiary>
+    <div class="q-dialog__content">
+      <h1 class="q-dialog-title">
+        ${config.modalTitle}
+      </h1>
+      <form ref="form" class="q-form" validate>
+        <schema-editor
+          if.bind="schema"
+          id="schema-editor--export"
+          schema.bind="schema"
+          data.bind="exportOptions"
+          show-notifications.bind="false"
+          ,
+          change.call="handleChange()"
+        >
+          <h2>Optionen</h2>
+        </schema-editor>
+      </form>
+      <div>
+        <preview-container
+          style="height: 500px;"
+          rendering-info.bind="renderingInfo"
+          target.bind="config.target.userExportable.previewTarget"
+          loading-status.bind="previewLoadingStatus"
+        ></preview-container>
+        <!-- <item-preview style="height: 500px;" target.bind="config.target.userExportable.previewTarget" id.bind="config.item.id"> -->
+      </div>
+    </div>
+    <div class="q-dialog__controls">
+      <button-secondary click.delegate="controller.cancel()"
+        >${config.cancelText & t}</button-secondary
+      >
+      <button-primary
+        is-loading.bind="isExportLoading"
+        click.delegate="export()"
+        >${config.proceedText & t}</button-primary
+      >
+    </div>
+  </div>
+</template>

--- a/client/src/dialogs/export-dialog.js
+++ b/client/src/dialogs/export-dialog.js
@@ -1,0 +1,128 @@
+import { inject, LogManager, TaskQueue } from "aurelia-framework";
+import { DialogController } from "aurelia-dialog";
+import QConfig from "resources/QConfig.js";
+import qEnv from "resources/qEnv.js";
+const log = LogManager.getLogger("Q");
+
+import { saveAs } from "file-saver";
+
+import AvailabilityChecker from "resources/checkers/AvailabilityChecker.js";
+import ToolEndpointChecker from "resources/checkers/ToolEndpointChecker.js";
+import ObjectFromSchemaGenerator from "resources/ObjectFromSchemaGenerator.js";
+
+@inject(
+  DialogController,
+  TaskQueue,
+  QConfig,
+  AvailabilityChecker,
+  ToolEndpointChecker,
+  ObjectFromSchemaGenerator
+)
+export class ExportDialog {
+  constructor(
+    controller,
+    taskQueue,
+    qConfig,
+    availabilityChecker,
+    toolEndpointChecker,
+    objectFromSchemaGenerator
+  ) {
+    this.controller = controller;
+    this.taskQueue = taskQueue;
+    this.qConfig = qConfig;
+    this.availabilityChecker = availabilityChecker;
+    this.toolEndpointChecker = toolEndpointChecker;
+    this.objectFromSchemaGenerator = objectFromSchemaGenerator;
+  }
+
+  async activate(config) {
+    this.config = config;
+
+    const QServerBaseUrl = await qEnv.QServerBaseUrl;
+
+    const response = await fetch(
+      `${QServerBaseUrl}/export-options-schema/${this.config.item.id}/${this.config.target.key}.json`
+    );
+    if (!response.ok || !(response.status >= 200 && response.status < 400)) {
+      log.error("failed to load exportOptionsSchema");
+      return;
+    }
+    this.schema = await response.json();
+    this.exportOptions = this.objectFromSchemaGenerator.generateFromSchema(
+      this.schema
+    );
+
+    if (!this.config.proceedText) {
+      this.config.proceedText = this.i18n.tr("general.yes");
+    }
+
+    if (!this.config.cancelText) {
+      this.config.cancelText = this.i18n.tr("general.no");
+    }
+    this.handleChange();
+  }
+
+  handleChange() {
+    this.taskQueue.queueMicroTask(() => {
+      // whenever we have a change in data, we need to reevaluate all the checks...
+      this.availabilityChecker.triggerReevaluation();
+      this.toolEndpointChecker.triggerReevaluation();
+      // ... and update the preview
+      this.renderingInfo = null;
+      this.previewLoadingStatus = "loading";
+      this.fetchRenderingInfo({ forPreview: true }).then(renderingInfo => {
+        this.previewLoadingStatus = "loaded";
+        this.renderingInfo = renderingInfo;
+      });
+    });
+  }
+
+  fetchRenderingInfo({ forPreview }) {
+    const toolRuntimeConfig = {
+      isPure: true,
+      exportOptions: this.exportOptions
+    };
+
+    const target = forPreview
+      ? this.config.target.userExportable.preview.target
+      : this.config.target.key;
+
+    return qEnv.QServerBaseUrl.then(QServerBaseUrl => {
+      if (this.config.item.id) {
+        return fetch(
+          `${QServerBaseUrl}/rendering-info/${
+            this.config.item.id
+          }/${target}?ignoreInactive=true&noCache=true&toolRuntimeConfig=${encodeURI(
+            JSON.stringify(toolRuntimeConfig)
+          )}`
+        );
+      }
+    })
+      .then(res => {
+        if (res.ok && res.status >= 200 && res.status < 400) {
+          if (res.headers.get("content-type").startsWith("application/json")) {
+            return res.json();
+          }
+          // if we do not have application/json here, we return the result as a blob (it's probably an image)
+          return res.blob();
+        }
+        throw res;
+      })
+      .then(renderingInfo => {
+        return renderingInfo;
+      });
+  }
+
+  async export() {
+    try {
+      this.isExportLoading = true;
+      const exportRenderingInfo = await this.fetchRenderingInfo({
+        forPreview: false
+      });
+      saveAs(exportRenderingInfo, `${this.config.item.id}-print.pdf`);
+      this.isExportLoading = false;
+    } catch (e) {
+      log.error("failed to load renderingInfo for export");
+    }
+  }
+}

--- a/client/src/elements/atoms/button-primary.html
+++ b/client/src/elements/atoms/button-primary.html
@@ -1,4 +1,19 @@
-<template bindable="click, icon, code, size, iconSize, tabindex, type, disabled" class="button">
+<template
+  bindable="click, icon, code, size, iconSize, tabindex, type, disabled, isLoading"
+  class="button"
+>
   <require from="./button-primary.css"></require>
-  <icon-button click.bind="click" icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex" type.bind="type" disabled.bind="disabled"><slot></slot></icon-button>
+  <icon-button
+    click.bind="click"
+    icon.bind="icon"
+    code.bind="code"
+    size.bind="size"
+    icon-size.bind="iconSize"
+    tabindex.bind="tabindex"
+    type.bind="type"
+    disabled.bind="disabled || isLoading"
+    is-loading.bind="isLoading"
+    secondary-loader.bind="true"
+    ><slot></slot
+  ></icon-button>
 </template>

--- a/client/src/elements/atoms/button-secondary.html
+++ b/client/src/elements/atoms/button-secondary.html
@@ -1,4 +1,18 @@
-<template bindable="click, icon, code, size, iconSize, tabindex, type, disabled" class="button">
+<template
+  bindable="click, icon, code, size, iconSize, tabindex, type, disabled, isLoading"
+  class="button"
+>
   <require from="./button-secondary.css"></require>
-  <icon-button click.bind="click" icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex" type.bind="type" disabled.bind="disabled"><slot></slot></icon-button>
+  <icon-button
+    click.bind="click"
+    icon.bind="icon"
+    code.bind="code"
+    size.bind="size"
+    icon-size.bind="iconSize"
+    tabindex.bind="tabindex"
+    type.bind="type"
+    disabled.bind="disabled || isLoading"
+    is-loading.bind="isLoading"
+    ><slot></slot
+  ></icon-button>
 </template>

--- a/client/src/elements/atoms/button-tertiary.html
+++ b/client/src/elements/atoms/button-tertiary.html
@@ -1,4 +1,19 @@
-<template bindable="click, icon, code, size, iconSize, tabindex, disabled" class="button">
+<template
+  bindable="click, icon, code, size, iconSize, tabindex, disabled, isLoading"
+  class="button"
+>
   <require from="./button-tertiary.css"></require>
-  <icon-button click.bind="click", icon.bind="icon" code.bind="code" size.bind="size" icon-size.bind="iconSize" tabindex.bind="tabindex" type.bind="type" disabled.bind="disabled"><slot></slot></icon-button>
+  <icon-button
+    click.bind="click"
+    ,
+    icon.bind="icon"
+    code.bind="code"
+    size.bind="size"
+    icon-size.bind="iconSize"
+    tabindex.bind="tabindex"
+    type.bind="type"
+    disabled.bind="disabled || isLoading"
+    is-loading.bind="isLoading"
+    ><slot></slot
+  ></icon-button>
 </template>

--- a/client/src/elements/atoms/icon-button.html
+++ b/client/src/elements/atoms/icon-button.html
@@ -1,10 +1,20 @@
 <template class="size-${size}">
   <require from="./icon-button.css"></require>
-  <button tabindex.bind="tabindex" type.bind="type" disabled.bind="disabled" click.trigger="click ? click() : true">
-    <span class="icon-button__icon" if.bind="code || icon">
-      <box-icon code.bind="code" icon.bind="icon" size="${iconSize || size}"></box-icon>
+  <button
+    tabindex.bind="tabindex"
+    type.bind="type"
+    disabled.bind="disabled || isLoading"
+    click.trigger="click ? click() : true"
+  >
+    <q-loader if.bind="isLoading" secondary.bind="secondaryLoader"></q-loader>
+    <span class="icon-button__icon" if.bind="(code || icon) && !isLoading">
+      <box-icon
+        code.bind="code"
+        icon.bind="icon"
+        size="${iconSize || size}"
+      ></box-icon>
     </span>
-    <span class="icon-button__text">
+    <span class="icon-button__text" css="${isLoading ? 'display: none;' : ''}">
       <slot></slot>
     </span>
   </button>

--- a/client/src/elements/atoms/icon-button.js
+++ b/client/src/elements/atoms/icon-button.js
@@ -8,5 +8,7 @@ export class IconButton {
   @bindable iconSize;
   @bindable tabindex;
   @bindable disabled;
+  @bindable isLoading = false;
+  @bindable secondaryLoader = false;
   @bindable type = "button";
 }

--- a/client/src/elements/atoms/q-loader.html
+++ b/client/src/elements/atoms/q-loader.html
@@ -1,3 +1,38 @@
-<template>
-  <img style="display: block; margin: 20px auto;" src="data:image/gif;base64,R0lGODlhEAALAPQAAP///xcTE93c3NTT0+vr6xwYGBcTE0A9PY2Li25ra8C/vzUyMlpXV5SSknFvb8PCwjk2NhoWFl1bW+jn59va2vT09ElGRt/e3vPy8ry7u6inp87Nze/v7wAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCwAAACwAAAAAEAALAAAFLSAgjmRpnqSgCuLKAq5AEIM4zDVw03ve27ifDgfkEYe04kDIDC5zrtYKRa2WQgAh+QQJCwAAACwAAAAAEAALAAAFJGBhGAVgnqhpHIeRvsDawqns0qeN5+y967tYLyicBYE7EYkYAgAh+QQJCwAAACwAAAAAEAALAAAFNiAgjothLOOIJAkiGgxjpGKiKMkbz7SN6zIawJcDwIK9W/HISxGBzdHTuBNOmcJVCyoUlk7CEAAh+QQJCwAAACwAAAAAEAALAAAFNSAgjqQIRRFUAo3jNGIkSdHqPI8Tz3V55zuaDacDyIQ+YrBH+hWPzJFzOQQaeavWi7oqnVIhACH5BAkLAAAALAAAAAAQAAsAAAUyICCOZGme1rJY5kRRk7hI0mJSVUXJtF3iOl7tltsBZsNfUegjAY3I5sgFY55KqdX1GgIAIfkECQsAAAAsAAAAABAACwAABTcgII5kaZ4kcV2EqLJipmnZhWGXaOOitm2aXQ4g7P2Ct2ER4AMul00kj5g0Al8tADY2y6C+4FIIACH5BAkLAAAALAAAAAAQAAsAAAUvICCOZGme5ERRk6iy7qpyHCVStA3gNa/7txxwlwv2isSacYUc+l4tADQGQ1mvpBAAIfkECQsAAAAsAAAAABAACwAABS8gII5kaZ7kRFGTqLLuqnIcJVK0DeA1r/u3HHCXC/aKxJpxhRz6Xi0ANAZDWa+kEAA7AAAAAAAAAAAA"/>
+<template bindable="secondary">
+  <style>
+    .q-loader {
+      display: block;
+      width: 36px;
+      height: 36px;
+      margin: 0 auto;
+      overflow: hidden;
+    }
+    .q-loader:after {
+      content: " ";
+      display: block;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      border: 5px solid #fff;
+      border-color: var(--q-color-primary-3) transparent
+        var(--q-color-primary-3) transparent;
+      animation: q-loader-lds-dual-ring 1.2s linear infinite;
+      transform-origin: 50% 50%;
+    }
+
+    .q-loader--secondary::after {
+      border-color: var(--q-color-white) transparent var(--q-color-white)
+        transparent;
+    }
+
+    @keyframes q-loader-lds-dual-ring {
+      0% {
+        transform: rotate(0deg);
+      }
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+  </style>
+  <div class="q-loader ${secondary ? 'q-loader--secondary' : ''}"></div>
 </template>

--- a/client/src/elements/item-preview/item-preview.js
+++ b/client/src/elements/item-preview/item-preview.js
@@ -109,10 +109,10 @@ export class ItemPreview {
       // set the default preview width to the most narrow variant
       this.previewWidthProxy.width = this.sizeOptions[0].value;
 
-      this.availableTargets = await this.qTargets.get("availableTargets");
+      const availableTargets = await this.qTargets.get("availableTargets");
 
       // get the list of publication filters
-      this.publications = await this.qConfig.get("publications");
+      const publications = await this.qConfig.get("publications");
 
       // wait for user loaded
       // get the users default publication
@@ -123,7 +123,7 @@ export class ItemPreview {
       if (this.user.data.publication) {
         let userDefaultPublication;
         // only use the users publication key if it is configured in the publications
-        for (let publication of this.publications) {
+        for (let publication of publications) {
           if (publication.key === this.user.data.publication) {
             userDefaultPublication = publication;
           }
@@ -132,7 +132,7 @@ export class ItemPreview {
           // only use the users default target if there is a target
           // available with the previewTarget key in the publication config
           let userDefaultTarget;
-          for (let target of this.availableTargets) {
+          for (let target of availableTargets) {
             if (target.key === userDefaultPublication.previewTarget) {
               userDefaultTarget = target;
             }
@@ -144,6 +144,11 @@ export class ItemPreview {
           }
         }
       }
+
+      if (!this.targetProxy.target) {
+        this.targetProxy.target = availableTargets[0];
+      }
+
       this.initialised = true;
     } catch (e) {
       log.error(e);

--- a/client/src/elements/item-preview/preview-container.html
+++ b/client/src/elements/item-preview/preview-container.html
@@ -14,9 +14,16 @@
 
     .preview-element {
       margin: auto;
-      min-height: calc(var(--q-preview-min-height) + 2 * var(--q-preview-padding) - 2px); /* minus 2px because of the border of the container */
+      min-height: calc(
+        var(--q-preview-min-height) + 2 * var(--q-preview-padding) - 2px
+      ); /* minus 2px because of the border of the container */
       box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.15);
       padding: var(--q-preview-padding);
+    }
+
+    .preview-element > img {
+      display: block;
+      object-fit: contain;
     }
 
     .preview-element__error-box {
@@ -36,10 +43,19 @@
     }
   </style>
   <div class="preview-element-container">
-    <div class="preview-element" css="width: calc(${width}px + (2 * var(--q-preview-padding))); color: ${previewColor}; background-color: ${previewColor};">
-      <div ref="previewElement" css="overflow: hidden; ${loadingStatus === 'loading' ? 'opacity: 0' : 'opacity: 1'};"></div>
+    <div
+      class="preview-element"
+      css="width: calc(${width}px + (2 * var(--q-preview-padding))); color: ${previewColor}; background-color: ${previewColor};"
+    >
+      <div
+        ref="previewElement"
+        css="overflow: hidden; ${loadingStatus === 'loading' ? 'opacity: 0' : 'opacity: 1'};"
+      ></div>
+      <q-loader if.bind="loadingStatus === 'loading'"></q-loader>
       <div class="preview-element__error-box" show.bind="error">
-        <h4 class="preview-element__error-text">${'preview.generalError.title' & t} ${'preview.generalError.body' & t}</h4>
+        <h4 class="preview-element__error-text">
+          ${'preview.generalError.title' & t} ${'preview.generalError.body' & t}
+        </h4>
       </div>
     </div>
   </div>

--- a/client/src/elements/item-preview/preview-container.js
+++ b/client/src/elements/item-preview/preview-container.js
@@ -30,6 +30,12 @@ export class PreviewContainer {
     this.showPreview(this.renderingInfo);
   }
 
+  detached() {
+    if (this.imageObjectURL) {
+      URL.revokeObjectURL(this.imageObjectURL);
+    }
+  }
+
   renderingInfoChanged(renderingInfo) {
     this.showPreview(this.renderingInfo);
   }
@@ -64,6 +70,24 @@ export class PreviewContainer {
       return;
     }
 
+    // if we have a Blob here, we display this as an Image
+    if (renderingInfo instanceof Blob) {
+      // cleanup
+      if (this.imageObjectURL) {
+        URL.revokeObjectURL(this.imageObjectURL);
+      }
+      if (this.imageElement) {
+        this.previewElement.removeChild(this.imageElement);
+      }
+
+      // create new image element and append to preview
+      this.imageElement = new Image();
+      this.imageObjectURL = URL.createObjectURL(renderingInfo);
+      this.imageElement.setAttribute("src", this.imageObjectURL);
+      this.previewElement.appendChild(this.imageElement);
+      return;
+    }
+
     const QServerBaseUrl = await qEnv.QServerBaseUrl;
 
     // remove all previously inserted elements
@@ -93,9 +117,7 @@ export class PreviewContainer {
         let link = document.createElement("link");
         link.type = "text/css";
         link.rel = "stylesheet";
-        link.href = `${
-          sophieConfig.buildServiceBaseUrl
-        }/bundle/${sophieModulesString}.css`;
+        link.href = `${sophieConfig.buildServiceBaseUrl}/bundle/${sophieModulesString}.css`;
         this.insertedElements.push(link);
         this.element.shadowRoot.appendChild(link);
       }

--- a/client/src/pages/item-overview.css
+++ b/client/src/pages/item-overview.css
@@ -28,6 +28,10 @@
   margin-bottom: calc(var(--q-space-base) * 2);
 }
 
+.item-overview__controls__exports {
+  margin-top: calc(var(--q-space-base) * 4);
+}
+
 .item-overview__status icon-active-state {
   float: right;
 }

--- a/client/src/pages/item-overview.html
+++ b/client/src/pages/item-overview.html
@@ -52,6 +52,12 @@
           <span t="item.delete"></span>
         </button-secondary>
 
+        <div class="item-overview__controls__exports">
+          <button-secondary click.delegate="exportWithModal(target)" repeat.for="target of userExportableTargets">
+            <span>${target.userExportable.buttonLabel & t}</span>
+          </button-secondary>
+        </div>
+
       </aside>
       <div>
   </main>

--- a/client/src/resources/QTargets.js
+++ b/client/src/resources/QTargets.js
@@ -30,4 +30,22 @@ export default class QTargets {
       return this.data[key];
     });
   }
+
+  getUserExportable({ tool }) {
+    return this.loaded.then(() => {
+      return this.data.availableTargets.filter(target => {
+        let isExportable =
+          target.userExportable !== false &&
+          target.userExportable !== undefined;
+        if (
+          isExportable === true &&
+          tool !== undefined &&
+          Array.isArray(target.userExportable.onlyTools)
+        ) {
+          isExportable = target.userExportable.onlyTools.includes(tool);
+        }
+        return isExportable;
+      });
+    });
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,54 +1,54 @@
 {
   "name": "@nzz/q-editor",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@hapi/accept": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.2.tgz",
-      "integrity": "sha512-UtXlTT59srtMr7ZRBzK2CvyWqFwlf78hPt9jEXqkwfbwiwRH1PRv/qkS8lgr5ZyoG6kfpU3xTgt2X91Yfe/6Yg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
+      "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
       "requires": {
-        "@hapi/boom": "7.4.2",
-        "@hapi/hoek": "6.2.1"
+        "@hapi/boom": "7.4.3",
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/address": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.1.tgz",
+      "integrity": "sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA=="
     },
     "@hapi/ammo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
-      "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.1.tgz",
+      "integrity": "sha512-NYFK27VSPGyQ/KmOQedpQH4PSjE7awLntepX68vrYtRvuJO21W1kX0bK2p3C+6ltUwtCQSvmNT8a4uMVAysC6Q==",
       "requires": {
-        "@hapi/hoek": "6.2.1"
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/b64": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.0.tgz",
-      "integrity": "sha512-hmfPC1aF7cP21489A/IWPC3s1GE+1eAteVwFcOWLwj0Pky8eHgvrXPSSko2IeCpxqOdZhYw71IFN8xKPdv3CtQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
       "requires": {
-        "@hapi/hoek": "6.2.1"
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/boom": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.2.tgz",
-      "integrity": "sha512-T2CYcTI0AqSvC6YC7keu/fh9LVSMzfoMLharBnPbOwmc+Cexj9joIc5yNDKunaxYq9LPuOwMS0f2B3S1tFQUNw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.3.tgz",
+      "integrity": "sha512-3di+R+BcGS7HKy67Zi6mIga8orf67GdR0ubDEVBG1oqz3y9B70LewsuCMCSvWWLKlI6V1+266zqhYzjMrPGvZw==",
       "requires": {
-        "@hapi/hoek": "6.2.1"
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/bounce": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.0.tgz",
-      "integrity": "sha512-gF5W/9AL10h/06HEf1bi0FP6KxZZ8LC/yHtDuoACw+1HrULvigHfnBIaSPFJXeHI3V3g0EkJpt1UOW0NKB+m+w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.1.tgz",
+      "integrity": "sha512-/ecFQTRBom2MEbjMHvKKE6FZ/e1gYK72CeUIFzz++dKK1kYJ0KbRJ72mXroWoTT2hIv+8H0ua/eOkO0+hRdHcw==",
       "requires": {
-        "@hapi/boom": "7.4.2",
-        "@hapi/hoek": "6.2.1"
+        "@hapi/boom": "7.4.3",
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/bourne": {
@@ -57,32 +57,32 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/call": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.0.tgz",
-      "integrity": "sha512-CiVEXjD/jiIHBqufBW3pdedshEMjRmHtff7m1puot8j4MUmuKRbLlh0DB8fv6QqH/7/55pH1qgFj300r0WpyMw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.1.tgz",
+      "integrity": "sha512-M6fC+9+K/ZB4hIdVQ8i0kc/6J5PWlW3PEWYKAAZpw0sk+28LiRTSF8BjOWwmiIjZWWs42AnEIiFJA0YrvcDnlw==",
       "requires": {
-        "@hapi/boom": "7.4.2",
-        "@hapi/hoek": "6.2.1"
+        "@hapi/boom": "7.4.3",
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/catbox": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.1.tgz",
-      "integrity": "sha512-u13BXlnmmrNUZssjTriRVTLuk6I/yUy5C1/Pia1+E2cpfd7o2/jmEvYdFgeS0Ft9QTz7WWhpXKlrguARUuohhQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.2.tgz",
+      "integrity": "sha512-a4KejaKqDOMdwo/PIYoAaObVMmkfkG3RS85kPqNTTURjWnIV1+rrZ938f6RCz5EbrroKbuNC0bcvAt7lAD5LNg==",
       "requires": {
-        "@hapi/boom": "7.4.2",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/joi": "15.0.0",
-        "@hapi/podium": "3.4.0"
+        "@hapi/boom": "7.4.3",
+        "@hapi/hoek": "8.2.2",
+        "@hapi/joi": "15.1.1",
+        "@hapi/podium": "3.4.1"
       }
     },
     "@hapi/catbox-memory": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.0.tgz",
-      "integrity": "sha512-libCGyufOZaJu6uE9nVXw/u8tqOt4ifNIrOSAsDjzS+af3vPJyid8faOICqKCAh3E338UAsUe5AeYdezdsmtpg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
+      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
       "requires": {
-        "@hapi/boom": "7.4.2",
-        "@hapi/hoek": "6.2.1"
+        "@hapi/boom": "7.4.3",
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/content": {
@@ -90,7 +90,7 @@
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
       "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
       "requires": {
-        "@hapi/boom": "7.4.2"
+        "@hapi/boom": "7.4.3"
       }
     },
     "@hapi/cryptiles": {
@@ -98,165 +98,172 @@
       "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
       "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
       "requires": {
-        "@hapi/boom": "7.4.2"
+        "@hapi/boom": "7.4.3"
       }
     },
+    "@hapi/file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
+      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
+    },
     "@hapi/hapi": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.1.tgz",
-      "integrity": "sha512-gBiU9isWWezrg0ucX95Ph6AY6fUKZub3FxKapaleoFBJDOUcxTYiQR6Lha2zvHalIFoTl3K04O3Yr/5pD17QkQ==",
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.2.tgz",
+      "integrity": "sha512-UJogSyMPe4VFfzjQW5v2ixLvTLZLSfPs1XV/DRnAl2znzsGCaNJI+tgNxjM9lszOjEEkMfxLgoXZadk9exnIxw==",
       "requires": {
-        "@hapi/accept": "3.2.2",
-        "@hapi/ammo": "3.1.0",
-        "@hapi/boom": "7.4.2",
-        "@hapi/bounce": "1.3.0",
-        "@hapi/call": "5.1.0",
-        "@hapi/catbox": "10.2.1",
-        "@hapi/catbox-memory": "4.1.0",
-        "@hapi/heavy": "6.2.0",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/joi": "15.0.0",
-        "@hapi/mimos": "4.1.0",
-        "@hapi/podium": "3.4.0",
-        "@hapi/shot": "4.1.0",
-        "@hapi/somever": "2.1.0",
-        "@hapi/statehood": "6.1.0",
-        "@hapi/subtext": "6.1.0",
+        "@hapi/accept": "3.2.3",
+        "@hapi/ammo": "3.1.1",
+        "@hapi/boom": "7.4.3",
+        "@hapi/bounce": "1.3.1",
+        "@hapi/call": "5.1.1",
+        "@hapi/catbox": "10.2.2",
+        "@hapi/catbox-memory": "4.1.1",
+        "@hapi/heavy": "6.2.1",
+        "@hapi/hoek": "8.2.2",
+        "@hapi/joi": "15.1.1",
+        "@hapi/mimos": "4.1.1",
+        "@hapi/podium": "3.4.1",
+        "@hapi/shot": "4.1.1",
+        "@hapi/somever": "2.1.1",
+        "@hapi/statehood": "6.1.1",
+        "@hapi/subtext": "6.1.1",
         "@hapi/teamwork": "3.3.1",
-        "@hapi/topo": "3.1.0"
+        "@hapi/topo": "3.1.3"
       }
     },
     "@hapi/heavy": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.0.tgz",
-      "integrity": "sha512-tzGU9cElY0IxRBudGB7tLFkdpBD8XQPfd6G7DSOnvHRK+q96UHGHn4t59Yd7kDpVucNkErWWYarsGx2KmKPkXA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.1.tgz",
+      "integrity": "sha512-uaEyC4AtGCGKt/LLBbdDQxJP1bFAbxiot6n/fwa4kyo6w8ULpXXCh8FxLlJ5mC06lqbAxQv45JyozIB6P4Dsig==",
       "requires": {
-        "@hapi/boom": "7.4.2",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/joi": "15.0.0"
+        "@hapi/boom": "7.4.3",
+        "@hapi/hoek": "8.2.2",
+        "@hapi/joi": "15.1.1"
       }
     },
     "@hapi/hoek": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.1.tgz",
-      "integrity": "sha512-+ryw4GU9pjr1uT6lBuErHJg3NYqzwJTvZ75nKuJijEzpd00Uqi6oiawTGDDf5Hl0zWmI7qHfOtaqB0kpQZJQzA=="
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
+      "integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g=="
     },
     "@hapi/inert": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.0.tgz",
-      "integrity": "sha512-ytsYA46CQOj8AJ3j4keRMj0S1k2XPMuhrlxo/uBY3EJvfRlRs8LtIBIYDW+kmcAqnVaZggcYq4ngKt9H/eEIAA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.1.tgz",
+      "integrity": "sha512-kovx94LVcT9jELc+k4xuR+1lsdmimjHKn9SpI/YAXDioO7m4YzksEBSmneH3ZwVWVnl2j66Sfzvs2IweHRxyNA==",
       "requires": {
-        "@hapi/ammo": "3.1.0",
-        "@hapi/boom": "7.4.2",
-        "@hapi/bounce": "1.3.0",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/joi": "15.0.0",
-        "lru-cache": "4.1.1"
+        "@hapi/ammo": "3.1.1",
+        "@hapi/boom": "7.4.3",
+        "@hapi/bounce": "1.3.1",
+        "@hapi/hoek": "8.2.2",
+        "@hapi/joi": "15.1.1",
+        "lru-cache": "4.1.5"
       }
     },
     "@hapi/iron": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.0.tgz",
-      "integrity": "sha512-+MK3tBPkEKd50SrDTRXa2DVvE0UTPFKxGbodlbQpNP9SVlxi+ZwA640VJtMNj84FZh81UUxda8AOLPRKFffnEA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.1.tgz",
+      "integrity": "sha512-QYfm6nofZ19pIxm8LR0lsANBabrdxqe0vUYKKI+0w9VdCetoove+dxfbLfduVDM72kh/RNOQG6E5/xyI826PcA==",
       "requires": {
-        "@hapi/b64": "4.2.0",
-        "@hapi/boom": "7.4.2",
+        "@hapi/b64": "4.2.1",
+        "@hapi/boom": "7.4.3",
         "@hapi/cryptiles": "4.2.0",
-        "@hapi/hoek": "6.2.1"
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/joi": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.0.tgz",
-      "integrity": "sha512-pLCfcSeT26g59jEKZntmzlqe19dRMDNxCFKGD4CriF8+9FAD3Mq1aWNuKIFpKpX+u3x8lxLKXolDwk0gYl3b2w==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "requires": {
-        "@hapi/address": "2.0.0",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/topo": "3.1.0"
+        "@hapi/address": "2.1.1",
+        "@hapi/bourne": "1.3.2",
+        "@hapi/hoek": "8.2.2",
+        "@hapi/topo": "3.1.3"
       }
     },
     "@hapi/mimos": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.0.tgz",
-      "integrity": "sha512-CkxOB15TFZDMl5tQ5qezKZvvBnkRYVc8YksNfA5TnqQMMsU7vGPyvuuNFqj+15bfEwHyM6qasxyQNdkX9B/cQw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
+      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
       "requires": {
-        "@hapi/hoek": "6.2.1",
-        "mime-db": "1.40.0"
+        "@hapi/hoek": "8.2.2",
+        "mime-db": "1.41.0"
       }
     },
     "@hapi/nigel": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.0.tgz",
-      "integrity": "sha512-IJyau32pz5Bf7pzUU/8AIn/SvPvhLMQcOel6kM7ECpKyPc895AwttSusRKfgTwfxZOEG6W8DnNv25gLtqrVFSg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
+      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
       "requires": {
-        "@hapi/hoek": "6.2.1",
-        "@hapi/vise": "3.1.0"
+        "@hapi/hoek": "8.2.2",
+        "@hapi/vise": "3.1.1"
       }
     },
     "@hapi/pez": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.0.tgz",
-      "integrity": "sha512-c+AxL8/cCj+7FB+tzJ5FhWKYP8zF7/7mA3Ft3a5y7h6YT26qzhj5d2JY27jur30KaZbrZAd4ofXXkqvE/IpJlA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
+      "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
       "requires": {
-        "@hapi/b64": "4.2.0",
-        "@hapi/boom": "7.4.2",
+        "@hapi/b64": "4.2.1",
+        "@hapi/boom": "7.4.3",
         "@hapi/content": "4.1.0",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/nigel": "3.1.0"
+        "@hapi/hoek": "8.2.2",
+        "@hapi/nigel": "3.1.1"
       }
     },
     "@hapi/podium": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.0.tgz",
-      "integrity": "sha512-IwyewAPGlCoq+g5536PKSDqSTfgpwbj+q4cBJpEUNqzwc5C5SM2stuFsULU7x1jKeWevfgWDoYWC75ML4IOYug==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.1.tgz",
+      "integrity": "sha512-WbwYr5nK+GIrCdgEbN8R7Mh7z+j9AgntOLQ/YQdeLtBp+uScVmW9FoycKdNS5uweO74xwICr28Ob0DU74a2zmg==",
       "requires": {
-        "@hapi/hoek": "6.2.1",
-        "@hapi/joi": "15.0.0"
+        "@hapi/hoek": "8.2.2",
+        "@hapi/joi": "15.1.1"
       }
     },
     "@hapi/shot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.0.tgz",
-      "integrity": "sha512-rpUU5cF08fqAZLLnue6Sy0osj1QMPbrYskehxtLFPdk7CwlPcu9N/wRtgu7vDHTQCKTkag6M8sjc8V8p8lSxpg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.1.tgz",
+      "integrity": "sha512-TrsqCyaq24XcdvD0bSi26hjwyQQy5q/nzpasbPNgPLoGnxW3sCWE7ws3ba6dd6Atb8TEh9QBD7mBQDCrMMz2Ig==",
       "requires": {
-        "@hapi/hoek": "6.2.1",
-        "@hapi/joi": "15.0.0"
+        "@hapi/hoek": "8.2.2",
+        "@hapi/joi": "15.1.1"
       }
     },
     "@hapi/somever": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.0.tgz",
-      "integrity": "sha512-kMPewbpgLd0MSlNg0bjvq57Levozbg7c3O0idpWRxRgXfXBALNATLf8GRVbnMehYXAh7YRD2mR/91kginDtJ2Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
+      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
       "requires": {
-        "@hapi/bounce": "1.3.0",
-        "@hapi/hoek": "6.2.1"
+        "@hapi/bounce": "1.3.1",
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/statehood": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.0.tgz",
-      "integrity": "sha512-qc8Qq3kg0b3XK7siXf6DK0wp+rcOrXv336kIP6YrtD9TbQ45TsBobwKkUXB+4R3GCCQ8a6tOj8FR/9bdtjKJCA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.1.tgz",
+      "integrity": "sha512-tMfS6B8QdrqTaKRUhHv6Ur7oPK6kcEZcnnvBK4IuaPZA9ma5UsyprTXkzbiB0V+0E56dMg3RabO1SABeZkzy6g==",
       "requires": {
-        "@hapi/boom": "7.4.2",
-        "@hapi/bounce": "1.3.0",
+        "@hapi/boom": "7.4.3",
+        "@hapi/bounce": "1.3.1",
         "@hapi/bourne": "1.3.2",
         "@hapi/cryptiles": "4.2.0",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/iron": "5.1.0",
-        "@hapi/joi": "15.0.0"
+        "@hapi/hoek": "8.2.2",
+        "@hapi/iron": "5.1.1",
+        "@hapi/joi": "15.1.1"
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.0.tgz",
-      "integrity": "sha512-dNL4IspNciKUK9RJuArwyS1MO07ZU64z4JrCzY1+vRKczYqin8M5i34cpOrQNP3pD/A/6IbRcFg0Jl0G6pwjnA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.1.tgz",
+      "integrity": "sha512-Y7NjKFRPwlzKRw5IdwRou42hR4IBQZolT+/DlvfSr/CBjGyu38n5+9LKfNKzqB/0AVEk+xynCijsx1o1UVWX8A==",
       "requires": {
-        "@hapi/boom": "7.4.2",
+        "@hapi/boom": "7.4.3",
         "@hapi/bourne": "1.3.2",
         "@hapi/content": "4.1.0",
-        "@hapi/hoek": "6.2.1",
-        "@hapi/pez": "4.1.0",
-        "@hapi/wreck": "15.0.1"
+        "@hapi/file": "1.0.0",
+        "@hapi/hoek": "8.2.2",
+        "@hapi/pez": "4.1.1",
+        "@hapi/wreck": "15.0.2"
       }
     },
     "@hapi/teamwork": {
@@ -265,476 +272,65 @@
       "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
     },
     "@hapi/topo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
-      "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
+      "integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
       "requires": {
-        "@hapi/hoek": "6.2.1"
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/vise": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.0.tgz",
-      "integrity": "sha512-DUDzV0D4iVO5atghsjGZtzaF0HVtRLcxcnH6rAONyH0stnoLiFloGEuP5nkbIPU0B9cgWTzTUsQPuNHBzxy9Yw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
+      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
       "requires": {
-        "@hapi/hoek": "6.2.1"
+        "@hapi/hoek": "8.2.2"
       }
     },
     "@hapi/wreck": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.1.tgz",
-      "integrity": "sha512-ByXQna/W1FZk7dg8NEhL79u4QkhzszRz76VpgyGstSH8bLM01a0C8RsxmUBgi6Tjkag5jA9kaEIhF9dLpMrtBw==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.2.tgz",
+      "integrity": "sha512-D/7sGmx3XxxkaMWHZDKTMai8rIEfIgE+DnoZeKfmxhKGgvIpMu1f8BBmLADbdniccGer79w74IWWdXleNrT1Rw==",
       "requires": {
-        "@hapi/boom": "7.4.2",
+        "@hapi/boom": "7.4.3",
         "@hapi/bourne": "1.3.2",
-        "@hapi/hoek": "6.2.1"
-      }
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
-      }
-    },
-    "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-      "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.1"
+        "@hapi/hoek": "8.2.2"
       }
     },
     "brok": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/brok/-/brok-3.1.0.tgz",
-      "integrity": "sha512-ISToLhRPWGwhhLEaJme1/MwL4kEF8qHYdIXLAjU/KwqSSbK0WcusR2QfxfmJloG9+tcB6WtDX81l9+RTedas3w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/brok/-/brok-4.0.0.tgz",
+      "integrity": "sha512-EkE1z0UAyqP1iGDxDzWpi7k/PObOJZN2vwLt93awpMqWI5qzuSbAeXTjgWzQjkd7XXdw1seemXMsJp0/d5ibqA==",
       "requires": {
-        "@hapi/hoek": "6.2.1",
-        "@hapi/joi": "15.0.0",
-        "iltorb": "2.2.0"
+        "@hapi/hoek": "6.2.4",
+        "@hapi/joi": "15.1.1"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+        }
       }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "1.0.0"
-      }
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-    },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "requires": {
-        "once": "1.4.0"
-      }
-    },
-    "expand-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-    },
-    "iltorb": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.2.0.tgz",
-      "integrity": "sha512-eD7cLpZudACV/Jww2aMfn9wwO5GhB2S3SSEl04Ru3vq+R7ZZEnbMTe3B3mlsz0heba9IFBivcqPfdXh9G5c+AA==",
-      "requires": {
-        "detect-libc": "1.0.3",
-        "nan": "2.10.0",
-        "npmlog": "4.1.2",
-        "prebuild-install": "2.5.1",
-        "which-pm-runs": "1.0.0"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-    },
-    "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
-      }
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-    },
-    "node-abi": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.3.0.tgz",
-      "integrity": "sha512-zwm6vU3SsVgw3e9fu48JBaRBCJGIvAgysDsqtf5+vEexFE71bEOtaMWb5zr/zODZNzTPtQlqUUpC79k68Hspow==",
-      "requires": {
-        "semver": "5.5.0"
-      }
-    },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "prebuild-install": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.1.tgz",
-      "integrity": "sha512-3DX9L6pzwc1m1ksMkW3Ky2WLgPQUBiySOfXVl3WZyAeJSyJb4wtoH9OmeRGcubAWsMlLiL8BTHbwfm/jPQE9Ag==",
-      "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.0",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.3.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.6",
-        "simple-get": "2.7.0",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
-      }
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.41.0.tgz",
+      "integrity": "sha512-B5gxBI+2K431XW8C2rcc/lhppbuji67nf9v39eH8pkWoZDxnAL0PxdpH32KYRScniF8qDHBDlI+ipgg5WrCUYw=="
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-    },
-    "simple-get": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
-      "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
-      }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "tar-fs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-      "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.5.5"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
-          }
-        }
-      }
-    },
-    "tar-stream": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
-      "requires": {
-        "bl": "1.2.2",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-    },
-    "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "requires": {
-        "string-width": "1.0.2"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {
@@ -35,8 +35,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@hapi/hapi": "^18.3.1",
-    "@hapi/inert": "^5.2.0",
-    "brok": "^3.1.0"
+    "@hapi/hapi": "^18.3.2",
+    "@hapi/inert": "^5.2.1",
+    "brok": "^4.0.0"
   }
 }


### PR DESCRIPTION
- feat: exportable targets. targets configured as exportable get a button on the item-overview page opening a modal allowing to download the renderingInfo of this target
- feat: buttons take an isLoading parameter to show a spinner when they are busy
- fix: if the user has no default preview target defined through the publication config, the first available target is used for the preview
