### PR TITLE
Feat export improvements

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -52,9 +52,11 @@ System.config({
     "leaflet": "github:Leaflet/Leaflet@1.3.1",
     "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
     "leaflet-search": "npm:leaflet-search@2.3.7",
+    "mime-db": "npm:mime-db@1.41.0",
     "mixin-deep": "npm:mixin-deep@2.0.0",
     "moment": "npm:moment@2.22.0",
     "set-value": "npm:set-value@3.0.0",
+    "slugify": "npm:slugify@1.3.5",
     "text": "github:systemjs/plugin-text@0.0.8",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.5.0"
@@ -340,6 +342,9 @@ System.config({
     },
     "npm:leaflet-search@2.3.7": {
       "leaflet": "npm:leaflet@1.3.1"
+    },
+    "npm:mime-db@1.41.0": {
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:path-browserify@0.0.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"

--- a/client/package.json
+++ b/client/package.json
@@ -81,9 +81,11 @@
       "leaflet": "github:Leaflet/Leaflet@1.3.1",
       "leaflet-geocoder-mapzen": "npm:leaflet-geocoder-mapzen@1.8.0",
       "leaflet-search": "npm:leaflet-search@2.3.7",
+      "mime-db": "npm:mime-db@^1.41.0",
       "mixin-deep": "npm:mixin-deep@^2.0.0",
       "moment": "npm:moment@2.22.0",
       "set-value": "npm:set-value@^3.0.0",
+      "slugify": "npm:slugify@^1.3.5",
       "text": "github:systemjs/plugin-text@^0.0.8"
     },
     "devDependencies": {}

--- a/client/src/dialogs/export-dialog.js
+++ b/client/src/dialogs/export-dialog.js
@@ -135,7 +135,7 @@ export class ExportDialog {
         exportRenderingInfo,
         `${this.slugify(this.config.item.conf.title)}-${
           this.config.item.id
-        }-print${extension}`
+        }${extension}`
       );
       this.isExportLoading = false;
     } catch (e) {

--- a/client/src/dialogs/export-dialog.js
+++ b/client/src/dialogs/export-dialog.js
@@ -1,4 +1,4 @@
-import { inject, LogManager, TaskQueue } from "aurelia-framework";
+import { inject, LogManager, TaskQueue, Loader } from "aurelia-framework";
 import { DialogController } from "aurelia-dialog";
 import QConfig from "resources/QConfig.js";
 import qEnv from "resources/qEnv.js";
@@ -13,6 +13,7 @@ import ObjectFromSchemaGenerator from "resources/ObjectFromSchemaGenerator.js";
 @inject(
   DialogController,
   TaskQueue,
+  Loader,
   QConfig,
   AvailabilityChecker,
   ToolEndpointChecker,
@@ -22,6 +23,7 @@ export class ExportDialog {
   constructor(
     controller,
     taskQueue,
+    loader,
     qConfig,
     availabilityChecker,
     toolEndpointChecker,
@@ -29,6 +31,7 @@ export class ExportDialog {
   ) {
     this.controller = controller;
     this.taskQueue = taskQueue;
+    this.loader = loader;
     this.qConfig = qConfig;
     this.availabilityChecker = availabilityChecker;
     this.toolEndpointChecker = toolEndpointChecker;
@@ -60,6 +63,9 @@ export class ExportDialog {
       this.config.cancelText = this.i18n.tr("general.no");
     }
     this.handleChange();
+
+    this.mimeDb = await this.loader.loadModule("mime-db");
+    this.slugify = await this.loader.loadModule("slugify");
   }
 
   handleChange() {
@@ -119,7 +125,18 @@ export class ExportDialog {
       const exportRenderingInfo = await this.fetchRenderingInfo({
         forPreview: false
       });
-      saveAs(exportRenderingInfo, `${this.config.item.id}-print.pdf`);
+      let extension = "";
+      const mimeInfo = this.mimeDb[exportRenderingInfo.type];
+      if (Array.isArray(mimeInfo.extensions.length)) {
+        extension = `.${mimeInfo.extension[0]}`;
+      }
+
+      saveAs(
+        exportRenderingInfo,
+        `${this.slugify(this.config.item.conf.title)}-${
+          this.config.item.id
+        }-print${extension}`
+      );
       this.isExportLoading = false;
     } catch (e) {
       log.error("failed to load renderingInfo for export");


### PR DESCRIPTION
*This improves the export dialog*
- file extension is taken from the content-type of the renderingInfo response now
- file title contains a slugified variant of the item title along the id
- mime-db and slugify get loaded when the export dialog opens