### PR TITLE
(export) allow limit of downloaded file name length

### DIFF
--- a/client/src/dialogs/export-dialog.html
+++ b/client/src/dialogs/export-dialog.html
@@ -15,7 +15,7 @@
     ></button-tertiary>
     <div class="q-dialog__content">
       <h1 class="q-dialog-title">
-        ${config.modalTitle}
+        ${config.target.modalTitle}
       </h1>
       <form ref="form" class="q-form" validate>
         <schema-editor

--- a/client/src/dialogs/export-dialog.js
+++ b/client/src/dialogs/export-dialog.js
@@ -131,15 +131,27 @@ export class ExportDialog {
         extension = `.${mimeInfo.extension[0]}`;
       }
 
-      saveAs(
-        exportRenderingInfo,
-        `${this.slugify(this.config.item.conf.title)}-${
-          this.config.item.id
-        }${extension}`
-      );
+      let filename = `${this.slugify(this.config.item.conf.title)}-${
+        this.config.item.id
+      }`;
+
+      if (
+        this.config.target.userExportable.download &&
+        this.config.target.userExportable.download.file &&
+        Number.isInteger(
+          this.config.target.userExportable.download.file.nameMaxLength
+        )
+      ) {
+        filename = filename.substr(
+          0,
+          this.config.target.userExportable.download.file.nameMaxLength
+        );
+      }
+
+      saveAs(exportRenderingInfo, `${filename}${extension}`);
       this.isExportLoading = false;
     } catch (e) {
-      log.error("failed to load renderingInfo for export");
+      log.error("failed to load renderingInfo for export", e);
     }
   }
 }

--- a/client/src/pages/item-overview.js
+++ b/client/src/pages/item-overview.js
@@ -118,8 +118,7 @@ export class ItemOverview {
         item: this.item,
         target: target,
         proceedText: "herunterladen",
-        cancelText: "schliessen",
-        modalTitle: target.userExportable.modalTitle
+        cancelText: "schliessen"
       }
     });
     const closeResult = await openDialogResult.closeResult;


### PR DESCRIPTION
- the userExportable config can contain `download.file.nameMaxLength` to limit the length of the filename
- this needs to be done because Woodwing has a problem with filenames longer than 60 characters
- Our server dev branch already contains the config for this
- This needs to be released before September 30th