### PR TITLE
Implements component schema-editor-dialog

### DIFF
--- a/client/locales/de/translation.json
+++ b/client/locales/de/translation.json
@@ -2,6 +2,8 @@
   "general": {
     "yes": "Ja",
     "no": "Nein",
+    "save": "Speichern",
+    "cancel": "Abbrechen",
     "createLabel": "Neu erstellen",
     "searchEditLabel": "Suchen und bearbeiten",
     "showAllTools": "Alle Tools anzeigen",
@@ -58,7 +60,8 @@
     "noAutosaveBecauseActive": "Automatisches speichern ist deaktiviert da die Grafik bereits aktiv ist",
     "required": "erforderlich",
     "transpose": "Zeilen und Spalten tauschen",
-    "bboxComponentNotice": "Hinweis: Shift gedrückt halten und Rechteck mit der Maus aufziehen um Ausschnitt zu definieren"
+    "bboxComponentNotice": "Hinweis: Shift gedrückt halten und Rechteck mit der Maus aufziehen um Ausschnitt zu definieren",
+    "openDialog": "Dialog öffnen"
   },
   "metaEditor": {
     "title": "Metainfos für den internen Gebrauch",

--- a/client/locales/en/translation.json
+++ b/client/locales/en/translation.json
@@ -2,6 +2,8 @@
   "general": {
     "yes": "yes",
     "no": "no",
+    "save": "save",
+    "cancel": "cancel",
     "createLabel": "Create a graphic",
     "searchEditLabel": "Search and edit",
     "showAllTools": "Show all tools",
@@ -58,7 +60,8 @@
     "noAutosaveBecauseActive": "Automatic saving is deactivated because the graphic is already active",
     "required": "required",
     "transpose": "Switch rows and columns",
-    "bboxComponentNotice": "Notice: Hold the Shift key and draw a rectangle with the mouse to define the visual area"
+    "bboxComponentNotice": "Notice: Hold the Shift key and draw a rectangle with the mouse to define the visual area",
+    "openDialog": "Open dialog"
   },
   "metaEditor": {
     "title": "Metainfos for internal use",

--- a/client/locales/fr/translation.json
+++ b/client/locales/fr/translation.json
@@ -2,6 +2,8 @@
   "general": {
     "yes": "Oui",
     "no": "Non",
+    "save": "Sauvegarder",
+    "cancel": "Abandonner",
     "createLabel": "Créer un graphique",
     "searchEditLabel": "Rechercher et modifier",
     "showAllTools": "Montrer tous les outils",
@@ -58,7 +60,8 @@
     "noAutosaveBecauseActive": "La sauvegarde automatique est désactivée car ce graphique est déjà actif",
     "required": "requis",
     "transpose": "Echange de lignes et de colonnes",
-    "bboxComponentNotice": "Remarque: maintenez la touche Maj enfoncée et tracez un rectangle avec la souris pour définir la zone visuelle"
+    "bboxComponentNotice": "Remarque: maintenez la touche Maj enfoncée et tracez un rectangle avec la souris pour définir la zone visuelle",
+    "openDialog": "Ouvrir le dialogue"
   },
   "metaEditor": {
     "title": "Informations pour usage interne",

--- a/client/src/dialogs/schema-editor-dialog.html
+++ b/client/src/dialogs/schema-editor-dialog.html
@@ -1,0 +1,22 @@
+<template>
+  <require from="../styles/q-dialog.css"></require>
+  <require from="elements/schema-editor/schema-editor"></require>
+  <div class="q-dialog q-dialog--medium q-dialog--centered q-dialog--bottom-controls">
+    <button-tertiary class="q-dialog__close-button" icon="close" icon-size="big" click.delegate="dialogController.cancel()"></button-tertiary>
+    <div class="q-dialog__content">
+      <form ref="form" class="q-form" validate>
+        <schema-editor
+          schema.bind="config.schema"
+          data.bind="config.data"
+          notifications.bind="config.notifications"
+          show-notifications.bind="config.showNotifications"
+          change.call="config.change()">
+        </schema-editor>
+      </form>
+    </div>
+    <div class="q-dialog__controls">
+      <button-secondary click.delegate="dialogController.cancel()">${ 'general.cancel' & t }</button-secondary>
+      <button-primary click.delegate="save()">${ 'general.save' & t }</button-primary>
+    </div>
+  </div>
+</template>

--- a/client/src/dialogs/schema-editor-dialog.html
+++ b/client/src/dialogs/schema-editor-dialog.html
@@ -9,8 +9,7 @@
           schema.bind="config.schema"
           data.bind="config.data"
           notifications.bind="config.notifications"
-          show-notifications.bind="config.showNotifications"
-          change.call="config.change()">
+          show-notifications.bind="config.showNotifications">
         </schema-editor>
       </form>
     </div>

--- a/client/src/dialogs/schema-editor-dialog.js
+++ b/client/src/dialogs/schema-editor-dialog.js
@@ -1,0 +1,20 @@
+import { inject } from "aurelia-framework";
+import { DialogController } from "aurelia-dialog";
+
+@inject(DialogController)
+export class SchemaEditorDialogImplementation {
+  constructor(dialogController) {
+    this.dialogController = dialogController;
+  }
+
+  activate(config) {
+    this.config = config;
+    delete this.config.schema["Q:options"].openInDialog;
+  }
+
+  save() {
+    if (this.form.checkValidity()) {
+      this.dialogController.ok(this.config.data);
+    }
+  }
+}

--- a/client/src/dialogs/schema-editor-dialog.js
+++ b/client/src/dialogs/schema-editor-dialog.js
@@ -9,6 +9,7 @@ export class SchemaEditorDialogImplementation {
 
   activate(config) {
     this.config = config;
+    // The openInDialog option needs to be deleted so the schema-editor renders the correct type. Otherwise it would just render the openInDialog button again.
     delete this.config.schema["Q:options"].openInDialog;
   }
 

--- a/client/src/elements/schema-editor/helpers.js
+++ b/client/src/elements/schema-editor/helpers.js
@@ -47,6 +47,10 @@ export function getType(schema) {
     type = "select";
   }
 
+  if (schema && schema["Q:options"] && schema["Q:options"].openInDialog) {
+    type = "dialog";
+  }
+
   return type;
 }
 

--- a/client/src/elements/schema-editor/schema-editor-dialog.css
+++ b/client/src/elements/schema-editor/schema-editor-dialog.css
@@ -1,0 +1,4 @@
+.schema-editor-dialog__button {
+  min-width: 200px;
+  width: 200px;
+}

--- a/client/src/elements/schema-editor/schema-editor-dialog.html
+++ b/client/src/elements/schema-editor/schema-editor-dialog.html
@@ -1,0 +1,11 @@
+<template class="schema-editor-input ${showNotifications ? 'schema-editor-input--with-notifications' : ''}">
+  <require from="./schema-editor-dialog.css"></require>
+  <div>
+    <button-primary
+    class="schema-editor-dialog__button"
+    click.delegate="open()">
+      <span if.bind="options.openInDialog.buttonText">${options.openInDialog.buttonText & toolT}</span>
+      <span else>${'editor.openDialog' & t}</span>
+    </button-primary>
+  </div>
+</template>

--- a/client/src/elements/schema-editor/schema-editor-dialog.js
+++ b/client/src/elements/schema-editor/schema-editor-dialog.js
@@ -18,8 +18,6 @@ export class SchemaEditorDialog {
   showNotifications;
 
   constructor(dialogService, i18n) {
-    this.getType = getType;
-    this.isRequired = isRequired;
     this.dialogService = dialogService;
     this.i18n = i18n;
   }
@@ -41,8 +39,7 @@ export class SchemaEditorDialog {
       viewModel: SchemaEditorDialogImplementation,
       model: {
         schema: this.schema,
-        data: this.data,
-        change: this.change,
+        data: JSON.parse(JSON.stringify(this.data)),
         notifications: this.notifications,
         showNotifications: this.showNotifications
       }

--- a/client/src/elements/schema-editor/schema-editor-dialog.js
+++ b/client/src/elements/schema-editor/schema-editor-dialog.js
@@ -1,0 +1,59 @@
+import { bindable, inject } from "aurelia-framework";
+import { DialogService } from "aurelia-dialog";
+import { I18N } from "aurelia-i18n";
+import { getType, isRequired } from "./helpers.js";
+import { SchemaEditorDialogImplementation } from "../../dialogs/schema-editor-dialog.js";
+
+@inject(DialogService, I18N)
+export class SchemaEditorDialog {
+  @bindable
+  schema;
+  @bindable
+  data;
+  @bindable
+  change;
+  @bindable
+  notifications;
+  @bindable
+  showNotifications;
+
+  constructor(dialogService, i18n) {
+    this.getType = getType;
+    this.isRequired = isRequired;
+    this.dialogService = dialogService;
+    this.i18n = i18n;
+  }
+
+  options = {};
+
+  schemaChanged() {
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    if (this.schema.hasOwnProperty("Q:options")) {
+      this.options = Object.assign(this.options, this.schema["Q:options"]);
+    }
+  }
+
+  async open() {
+    const dialog = await this.dialogService.open({
+      viewModel: SchemaEditorDialogImplementation,
+      model: {
+        schema: this.schema,
+        data: this.data,
+        change: this.change,
+        notifications: this.notifications,
+        showNotifications: this.showNotifications
+      }
+    });
+
+    const dialogResult = await dialog.closeResult;
+    if (!dialogResult.wasCancelled) {
+      this.data = dialogResult.output;
+      if (this.change) {
+        this.change();
+      }
+    }
+  }
+}

--- a/client/src/elements/schema-editor/schema-editor-dialog.js
+++ b/client/src/elements/schema-editor/schema-editor-dialog.js
@@ -1,7 +1,6 @@
 import { bindable, inject } from "aurelia-framework";
 import { DialogService } from "aurelia-dialog";
 import { I18N } from "aurelia-i18n";
-import { getType, isRequired } from "./helpers.js";
 import { SchemaEditorDialogImplementation } from "../../dialogs/schema-editor-dialog.js";
 
 @inject(DialogService, I18N)

--- a/client/src/elements/schema-editor/schema-editor-wrapper.html
+++ b/client/src/elements/schema-editor/schema-editor-wrapper.html
@@ -208,6 +208,18 @@
       show-notifications.bind="showNotifications"
     ></schema-editor-files>
   </div>
+
+  <div if.bind="getType(schema) === 'dialog'" class="schema-editor-block">
+    <require from="./schema-editor-dialog"></require>
+    <schema-editor-dialog
+      schema.bind="schema"
+      data.two-way="data"
+      change.bind="change"
+      required.bind="required"
+      notifications.bind="notifications"
+      show-notifications.bind="showNotifications"
+    ></schema-editor-dialog>
+  </div>
   <notification
     if.bind="showNotifications && visibleNotification"
     notification.bind="visibleNotification"

--- a/client/src/styles/q-dialog.css
+++ b/client/src/styles/q-dialog.css
@@ -16,6 +16,11 @@
   top: calc(var(--q-space-base) * 10);
 }
 
+.q-dialog--medium {
+  max-width: 1260px;
+  top: calc(var(--q-space-base) * 10);
+}
+
 .q-dialog-subtitle {
   margin: calc(var(--q-space-base) * 3) 0;
 }


### PR DESCRIPTION
This PR implements the component `schema-editor-dialog`. It allows to open a part of the schema in a dialog:
- The tool schema can define the `Q:options` property `openInDialog` to define that this subtree of the schema should be open in a dialog:
```json
{
"bbox": {
      "title": "Sichtbarer Kartenausschnitt",
      "Q:type": "bbox",
      "Q:options": {
        "openInDialog": true,
        "openInDialog": {  // Or if you want to define a custom button text
          "buttonText": "Kartenbereich definieren"
        }
      },
      "type": "array",
      "maxItems": 4,
      "items": {
        "type": "number"
      }
    }
}
```
The component displays a button with default text "Open dialog" or a custom text:
![Screenshot 2019-09-12 at 17 22 18](https://user-images.githubusercontent.com/1810384/64797631-f89c4880-d581-11e9-9abe-4d5c9f322f67.png)

Opening the dialog will render the sub-schema in a new schema-editor:

![Screenshot 2019-09-12 at 17 23 15](https://user-images.githubusercontent.com/1810384/64797713-179ada80-d582-11e9-9771-1d5e4b8800cd.png)

- The changes can be saved or canceled
- HTML Form validation for required fields will be trigger on save
- Checks are triggered on change as the change method is passed to the dialog
- This branch is deployed on st-test -> https://q.st-test.nzz.ch/editor/locator_map/2da04d68b4b415437bbe0fb95b25d897



