### PR TITLE
(livingdocs-component) use item specific display-options route

### DIFF
--- a/client/src/livingdocs-component-app/app.js
+++ b/client/src/livingdocs-component-app/app.js
@@ -148,8 +148,7 @@ export class App {
 
     if (tool) {
       toolConfig = {
-        icon: tool.icon,
-        hasDynamicDisplayOptions: tool.hasDynamicDisplayOptions
+        icon: tool.icon
       };
     }
     return toolConfig;
@@ -212,17 +211,8 @@ export class App {
   async getDisplayOptionsSchema() {
     try {
       let displayOptionsSchema = {};
-      let queryString = "";
-
-      // if the tool supports dynamic displayOptions the item should be appended to the request
-      // in order for the tool to extract the displayOptionsSchema from the item
-      if (this.selectedItem.toolConfig.hasDynamicDisplayOptions) {
-        queryString = `?appendItemToPayload=${this.selectedItem.id}`;
-      }
       const response = await fetch(
-        `${this.QServerBaseUrl}/tools/${
-          this.selectedItem.conf.tool
-        }/display-options-schema.json${queryString}`
+        `${this.QServerBaseUrl}/display-options-schema/${this.selectedItem.id}/${this.target.key}.json`
       );
       if (response.ok) {
         displayOptionsSchema = await response.json();


### PR DESCRIPTION
This PR implements using the new item specific display-options route. This route also handles dynamic-display options. Therefore the property `hasDynamicDisplayOptions` is removed in Q-Editor and the toolConfig in Q-Server-NZZ. 

Can be tested here: https://edit-stage.nzz.ch/articles/1276263/edit/component/doc-1dn82bmc30/include/q-embed/0