### PR TITLE
(preview) fix the preview of image type rendering info

### DIFF
--- a/client/src/elements/item-preview/preview-container.js
+++ b/client/src/elements/item-preview/preview-container.js
@@ -36,7 +36,7 @@ export class PreviewContainer {
     }
   }
 
-  renderingInfoChanged(renderingInfo) {
+  renderingInfoChanged() {
     this.showPreview(this.renderingInfo);
   }
 
@@ -66,6 +66,12 @@ export class PreviewContainer {
     }
 
     if (!renderingInfo) {
+      if (
+        this.imageElement &&
+        this.imageElement.parentNode === this.previewElement
+      ) {
+        this.previewElement.removeChild(this.imageElement);
+      }
       this.previewElement.innerHTML = "";
       return;
     }
@@ -75,9 +81,6 @@ export class PreviewContainer {
       // cleanup
       if (this.imageObjectURL) {
         URL.revokeObjectURL(this.imageObjectURL);
-      }
-      if (this.imageElement) {
-        this.previewElement.removeChild(this.imageElement);
       }
 
       // create new image element and append to preview


### PR DESCRIPTION
This fixes a bug where the imageElement in the preview was removed from the previewElement at the wrong spot where it was already gone.