### PR TITLE
v6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.1.1 (22.10.2019)
+
+- fix: chaing the renderingInfo when using image type renderingInfo works in the preview-container now.
+- fix: add spacing between multiple export buttons on item overview page
+
 # 6.1.0 (17.10.2019)
 
 - feat: use new display-options route in livingdocs-component which makes display-options more configurable

--- a/client/src/elements/item-preview/preview-container.js
+++ b/client/src/elements/item-preview/preview-container.js
@@ -36,7 +36,7 @@ export class PreviewContainer {
     }
   }
 
-  renderingInfoChanged(renderingInfo) {
+  renderingInfoChanged() {
     this.showPreview(this.renderingInfo);
   }
 
@@ -66,6 +66,12 @@ export class PreviewContainer {
     }
 
     if (!renderingInfo) {
+      if (
+        this.imageElement &&
+        this.imageElement.parentNode === this.previewElement
+      ) {
+        this.previewElement.removeChild(this.imageElement);
+      }
       this.previewElement.innerHTML = "";
       return;
     }
@@ -75,9 +81,6 @@ export class PreviewContainer {
       // cleanup
       if (this.imageObjectURL) {
         URL.revokeObjectURL(this.imageObjectURL);
-      }
-      if (this.imageElement) {
-        this.previewElement.removeChild(this.imageElement);
       }
 
       // create new image element and append to preview

--- a/client/src/pages/item-overview.css
+++ b/client/src/pages/item-overview.css
@@ -32,6 +32,12 @@
   margin-top: calc(var(--q-space-base) * 4);
 }
 
+.item-overview__controls__exports > * {
+  width: 100%;
+  flex-grow: 0;
+  margin-bottom: calc(var(--q-space-base) * 2);
+}
+
 .item-overview__status icon-active-state {
   float: right;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
- fix: chaing the renderingInfo when using image type renderingInfo works in the preview-container now.
- fix: add spacing between multiple export buttons on item overview page