### PR TITLE
Release 6.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- fix: show only the selected tools also if the users config still contains tools that are not available anymore
+
 # 6.1.1 (22.10.2019)
 
 - fix: chaing the renderingInfo when using image type renderingInfo works in the preview-container now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 6.1.2 (28.10.2019)
+
 - fix: show only the selected tools also if the users config still contains tools that are not available anymore
 
 # 6.1.1 (22.10.2019)

--- a/client/src/elements/organisms/tool-selection.js
+++ b/client/src/elements/organisms/tool-selection.js
@@ -42,15 +42,12 @@ export class ToolSelection {
       // set the alwaysVisibleToolCount to the number of tools the user has checked as
       // visible initially
       this.alwaysVisibleToolCount = Object.keys(userToolSelectionConfig.tools)
-        .map(toolName => {
-          return isInInitialToolSelection(userToolSelectionConfig, toolName);
+        .filter(toolName => {
+          return this.tools.find(tool => tool.name === toolName); // only keep the tools that are available
         })
-        .reduce((amountVisibleTools, isToolVisible) => {
-          if (isToolVisible) {
-            return amountVisibleTools + 1;
-          }
-          return amountVisibleTools;
-        }, 0);
+        .filter(toolName => {
+          return isInInitialToolSelection(userToolSelectionConfig, toolName);
+        }).length;
 
       // sort the tools by their config value for inInitialToolSelection;
       this.visibleTools = this.tools.slice(0).sort((a, b) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
- fix: show only the selected tools also if the users config still contains tools that are not available anymore