### PR TITLE
Improves ToolEndpointChecks and geojson-component search input

### DIFF
--- a/client/src/dialogs/schema-editor-dialog.js
+++ b/client/src/dialogs/schema-editor-dialog.js
@@ -8,7 +8,7 @@ export class SchemaEditorDialogImplementation {
   }
 
   activate(config) {
-    this.config = config;
+    this.config = JSON.parse(JSON.stringify(config));
     // The openInDialog option needs to be deleted so the schema-editor renders the correct type. Otherwise it would just render the openInDialog button again.
     delete this.config.schema["Q:options"].openInDialog;
   }

--- a/client/src/elements/schema-editor/schema-editor-bbox.js
+++ b/client/src/elements/schema-editor/schema-editor-bbox.js
@@ -71,11 +71,18 @@ export class SchemaEditorBbox {
     if (schemaEditorConfig.shared.map.accessToken) {
       mapboxgl.accessToken = schemaEditorConfig.shared.map.accessToken;
     }
-    this.map = new mapboxgl.Map({
+
+    const options = {
       container: this.mapContainer,
       style: schemaEditorConfig.shared.map.style,
-      maxZoom: schemaEditorConfig.shared.map.maxZoom
-    });
+      maxZoom: schemaEditorConfig.shared.map.maxZoom,
+      fitBoundsOptions: { padding: 60, duration: 0 }
+    };
+
+    if (this.schema.bounds) {
+      options.bounds = this.schema.bounds;
+    }
+    this.map = new mapboxgl.Map(options);
 
     this.map.addControl(
       new mapboxgl.NavigationControl({ showCompass: false }),
@@ -116,7 +123,10 @@ export class SchemaEditorBbox {
     this.map.on("draw.update", event => {
       this.data = bbox(event.features[0]);
       this.map.fitBounds(
-        [[this.data[0], this.data[1]], [this.data[2], this.data[3]]],
+        [
+          [this.data[0], this.data[1]],
+          [this.data[2], this.data[3]]
+        ],
         { padding: 60, duration: 0 }
       );
     });
@@ -158,7 +168,10 @@ export class SchemaEditorBbox {
     }
     this.MapboxDraw.set(bboxFeatureCollection);
     this.map.fitBounds(
-      [[this.data[0], this.data[1]], [this.data[2], this.data[3]]],
+      [
+        [this.data[0], this.data[1]],
+        [this.data[2], this.data[3]]
+      ],
       { padding: 60, duration: 0 }
     );
   }

--- a/client/src/elements/schema-editor/schema-editor-geojson-point.js
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.js
@@ -173,7 +173,7 @@ export class SchemaEditorGeojsonPoint {
         },
         placeHolder: "Suche",
         selector: `#${this.autoCompleteInputId}`,
-        debounce: 300,
+        debounce: 1000,
         searchEngine: "strict",
         resultsList: {
           render: true,

--- a/client/src/pages/editor.js
+++ b/client/src/pages/editor.js
@@ -208,21 +208,21 @@ export class Editor {
     }
   }
 
-  triggerReevaluations() {
+  async triggerReevaluations() {
     // emtpy the notifications as we will get new ones
     this.editorNotifications = [];
     this.optionsNotifications = [];
     this.availabilityChecker.triggerReevaluation();
     this.notificationChecker.triggerReevaluation();
-    this.toolEndpointChecker.triggerReevaluation();
+    await this.toolEndpointChecker.triggerReevaluation();
   }
 
-  handleChange() {
-    this.taskQueue.queueMicroTask(() => {
+  async handleChange() {
+    this.taskQueue.queueMicroTask(async () => {
       this.item.changed();
 
       // whenever we have a change in data, we need to reevaluate all the checks...
-      this.triggerReevaluations();
+      await this.triggerReevaluations();
       // ... and update thte previewData to fetch new renderingInfo from the tool
       this.previewData = JSON.parse(JSON.stringify(this.item.conf));
     });

--- a/client/src/resources/checkers/ToolEndpointChecker.js
+++ b/client/src/resources/checkers/ToolEndpointChecker.js
@@ -10,9 +10,9 @@ export default class ToolEndpointChecker {
     this.currentItemProvider = currentItemProvider;
   }
 
-  triggerReevaluation() {
+  async triggerReevaluation() {
     for (let cb of this.reevaluateCallbacks) {
-      cb();
+      await cb();
     }
   }
 


### PR DESCRIPTION
- This PR does the following:
  - Awaits ToolEndpointChecks before rendering the preview. This change is necessary for the highlight region feature in the maps tool
  - Increases time to input region name in geojson-compontent to 1s
  - Adds an optional property `bounds` to the bbox-component, which allows the tool to define a bound in the schema.
- This PR is deployed on staging -> https://q.st-staging.nzz.ch/editor/locator_map/6dcf203a5c5f74b61aeea0cb0e45692d