### PR TITLE
Release 6.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.2.5 (29.04.2020)
+
+- fix: Preview loads item twice on page load of item overview page
+
 # 6.2.4 (19.02.2020)
 
 - fix: Use patched version of handsontable

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Demo: https://editor.q.tools
 git clone git@github.com:nzzdev/Q-editor.git
 cd ./Q-editor
 npm install
-npm run build
 ```
 
 ## Configuration
@@ -351,13 +350,12 @@ You need [Node.js](https://nodejs.org/) and `npm`.
 When you have this installed running the following commands in the root of this project should give you a working environment.
 
 ```
-npm install -g jspm
 cd client
 npm install
-jspm install
+npx jspm install
 ```
 
-After that you can start a live reloading webserver by running `gulp watch` within the folder `client`.
+After that you can start a live reloading webserver by running `npx gulp watch` within the folder `client`.
 
 ## Testing
 
@@ -392,6 +390,6 @@ If you choose to build your own docker image or deploy it some other way make su
 
 ## License
 
-Copyright (c) 2019 Neue Zürcher Zeitung. All rights reserved.
+Copyright (c) 2020 Neue Zürcher Zeitung. All rights reserved.
 
 This software is published under the MIT license.

--- a/client/src/elements/item-preview/item-preview.js
+++ b/client/src/elements/item-preview/item-preview.js
@@ -155,10 +155,6 @@ export class ItemPreview {
     }
   }
 
-  attached() {
-    this.loadPreview();
-  }
-
   getCurrentSizeOption() {
     return this.sizeOptions.find(option => {
       return option.value === this.previewWidthProxy.width;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
## Fix duplicate loading of preview on first page load

Before this fix, the following was happening on the item-overview page:
- `loadPreview()` is called from `targetProxy` when `target` is set
- `loadPreview()` is called again from the `attached()` life-cycle hook

As far as I can tell, the call from attached() was not required; the preview is still working on the overview page and inside the editor.

Deployed on staging, [the test item](https://q.st-staging.nzz.ch/item/6dcf203a5c5f74b61aeea0cb0eef8942) now only loads once.

Fixes #235