### PR TITLE
fix for readonly cells

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -238,7 +238,9 @@ export class SchemaEditorTable {
     return array2d.map(predefinedContent, (cell, i, j) => {
       if (typeof cell === "object" && cell !== null) {
         return cell.value;
-      } else return cell;
+      } else {
+        return cell;
+      }
     });
   }
 

--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -234,13 +234,12 @@ export class SchemaEditorTable {
     return !hasNonPredefinedData;
   }
 
-  getValuesFromPredefinedContent(content) {
-    array2d.eachCell(content, (cell, i, j) => {
+  getValuesFromPredefinedContent(predefinedContent) {
+    return array2d.map(predefinedContent, (cell, i, j) => {
       if (typeof cell === "object" && cell !== null) {
-        content[i][j] = cell.value;
-      }
+        return cell.value;
+      } else return cell;
     });
-    return content;
   }
 
   applyOptions() {
@@ -249,6 +248,7 @@ export class SchemaEditorTable {
     }
     if (this.schema.hasOwnProperty("Q:options")) {
       this.options = Object.assign(this.options, this.schema["Q:options"]);
+      debugger;
 
       if (this.schema["Q:options"].hasOwnProperty("predefinedContent")) {
         const predefinedContent = this.schema["Q:options"].predefinedContent;
@@ -298,8 +298,13 @@ export class SchemaEditorTable {
           const predefinedContent = this.schema["Q:options"].predefinedContent
             .data;
           if (predefinedContent) {
+            console.log(
+              `predefined content found for row ${row} and column ${col}`
+            );
+            debugger;
             try {
               const predefinedCell = predefinedContent[row][col];
+              console.log(predefinedCell);
               if (
                 predefinedCell !== undefined &&
                 predefinedCell !== null &&

--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -248,7 +248,6 @@ export class SchemaEditorTable {
     }
     if (this.schema.hasOwnProperty("Q:options")) {
       this.options = Object.assign(this.options, this.schema["Q:options"]);
-      debugger;
 
       if (this.schema["Q:options"].hasOwnProperty("predefinedContent")) {
         const predefinedContent = this.schema["Q:options"].predefinedContent;
@@ -298,13 +297,8 @@ export class SchemaEditorTable {
           const predefinedContent = this.schema["Q:options"].predefinedContent
             .data;
           if (predefinedContent) {
-            console.log(
-              `predefined content found for row ${row} and column ${col}`
-            );
-            debugger;
             try {
               const predefinedCell = predefinedContent[row][col];
-              console.log(predefinedCell);
               if (
                 predefinedCell !== undefined &&
                 predefinedCell !== null &&


### PR DESCRIPTION
Discovered a bug when writing predefined content to data table:
* before: when gathering predefined values the predefined content array holding readOnly information was overwritten
* fixed: map original array to gather values to a new array and keep original

Can be tested on `test` (on `staging` one can see the old behavior of not having readOnly cells).