### PR TITLE
Ignore rows/columns which differ of range of predefinedValues

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-table.js
+++ b/client/src/elements/schema-editor/schema-editor-table.js
@@ -215,22 +215,27 @@ export class SchemaEditorTable {
 
     let hasNonPredefinedData = false;
     const predefinedValues = predefinedContent.data;
-
-    array2d.eachCell(this.data, (cell, i, j) => {
-      // if overwrites are not allowed per default we check if there are values in cells
-      // which are not cells with predefined content and block overwrites in that case
-      if (cell !== undefined && cell !== null && cell !== "") {
-        const predefinedRow = predefinedValues[i];
-        if (predefinedRow) {
-          const predefinedCell = predefinedRow[j];
-          if (!predefinedCell) {
+    if (array2d.cells(this.data) > 0) {
+      // predefinedValues can be of different dimensions (amount of rows and columns).
+      // rows and columns which are not in the predefinedValues range are ignored
+      const dimensions = array2d.dimensions(predefinedValues);
+      const data = array2d.crop(this.data, 0, 0, dimensions[0], dimensions[1]);
+      array2d.eachCell(data, (cell, i, j) => {
+        // if overwrites are not allowed per default we check if there are values in cells
+        // which are not cells with predefined content and block overwrites in that case
+        if (cell !== undefined && cell !== null && cell !== "") {
+          const predefinedRow = predefinedValues[i];
+          if (predefinedRow) {
+            const predefinedCell = predefinedRow[j];
+            if (!predefinedCell) {
+              hasNonPredefinedData = true;
+            }
+          } else {
             hasNonPredefinedData = true;
           }
-        } else {
-          hasNonPredefinedData = true;
         }
-      }
-    });
+      });
+    }
     return !hasNonPredefinedData;
   }
 


### PR DESCRIPTION
This PR improves the `isOverwritingAllowed` function. Rows and columns which are not in the range of the predefinedValues array will be ignored. The old behaviour was preventing switching between basemaps which have different dimentions (Switzerland has 26 Cantons and Germany has 401 Landkreise)

This change can be tested by comparing the behaviour on test and staging. This branch is deployed on test and can be tested by creating a new choropleth map and switching the basemap from Germany back to Switzerland. On staging the old editor is deployed and switching back doesn't work.