### PR TITLE
Release v6.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.3.3 (05.01.2021)
+
+- fix: (notifications) allow empty responses of ToolEndpoint requests
+
 # 6.3.2 (16.12.2020)
 
 - fix: (schema-editor-table) ignore rows/columns which differ of range of predefinedValues

--- a/client/src/resources/checkers/ToolEndpointChecker.js
+++ b/client/src/resources/checkers/ToolEndpointChecker.js
@@ -51,7 +51,7 @@ export default class ToolEndpointChecker {
       options
     );
 
-    // Acceptable status codes of response are 200 (ok) or 204 (no content)
+    // allow empty responses of ToolEndpoint requests (204 - no content)
     if (response && ![200, 204].includes(response.status)) {
       throw new Error(response.statusMessage);
     }

--- a/client/src/resources/checkers/ToolEndpointChecker.js
+++ b/client/src/resources/checkers/ToolEndpointChecker.js
@@ -33,12 +33,12 @@ export default class ToolEndpointChecker {
     const item = this.currentItemProvider.getCurrentItem().conf;
     const toolRequestBaseUrl = `${QServerBaseUrl}/tools/${item.tool}`;
     const options = {
-      method: "GET"
+      method: "GET",
     };
 
     if (Array.isArray(config.fields) && config.fields.length > 0) {
       const dataForEndpoint = {
-        item: this.currentItemProvider.getCurrentItemByFields(config.fields)
+        item: this.currentItemProvider.getCurrentItemByFields(config.fields),
       };
       options.method = "POST";
       if (config.hasOwnProperty("options")) {
@@ -51,7 +51,8 @@ export default class ToolEndpointChecker {
       options
     );
 
-    if (response.status !== 200) {
+    // Acceptable status codes of response are 200 (ok) or 204 (no content)
+    if (response && ![200, 204].includes(response.status)) {
       throw new Error(response.statusMessage);
     }
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-editor",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "description": "Q Editor - The editor part of the Q toolbox",
   "homepage": "https://github.com/nzzdev/Q-editor",
   "bugs": {


### PR DESCRIPTION
Fixes https://github.com/nzzdev/Q-editor/issues/292

This branch is deployed on [staging](https://q.st-staging.nzz.ch/item/choropleth-17) for testing. Before this change empty responses from ToolEndpoint requests were treated as errors. After this change empty responses are allowed and not treated as errors anymore.