### PR TITLE
Specify user language for geolocator query results to de & en

### DIFF
--- a/client/src/elements/schema-editor/schema-editor-geojson-point.js
+++ b/client/src/elements/schema-editor/schema-editor-geojson-point.js
@@ -231,7 +231,7 @@ export class SchemaEditorGeojsonPoint {
 
   geocode(query, key) {
     return fetch(
-      `https://api.maptiler.com/geocoding/${query}.json?key=${key}`
+      `https://api.maptiler.com/geocoding/${query}.json?key=${key}&language=de,en`
     ).then((response) => response.json());
   }
 


### PR DESCRIPTION
**test steps**
1. Open q
2. Create map
3. Add point
4. Enter 'Donezk' in geolocation search field (top right on mapbox map)
5. Entry with 'Donezk' as name should appear (latin instead of cyrillic characters)